### PR TITLE
Use jgitver for versioning

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <groupId>fr.brouillard.oss</groupId>
+        <artifactId>jgitver-maven-plugin</artifactId>
+        <version>1.2.1</version>
+    </extension>
+</extensions>

--- a/.mvn/jgitver.config.xml
+++ b/.mvn/jgitver.config.xml
@@ -1,0 +1,6 @@
+<configuration xmlns="http://jgitver.github.io/maven/configuration/1.0.0-beta"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.0.0-beta https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_0_0-beta.xsd ">
+    <regexVersionTag>[rv]?([0-9.]+)</regexVersionTag>
+</configuration>
+

--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ These are the entry point for developers:
 an implementation of either results in an OpenML provider that can be used for, respectively, loading and training external algorithms to those already provided by Feedzai.
 
 The `openml-example` project shows a trivial implementation of those concepts.
+
+### IDE Compatibility
+
+This project makes use of the [jgitver Maven plugin](https://github.com/jgitver/jgitver). When using Intellij IDEA you
+must configure the project to skip the plugin altogether: [see issue](https://github.com/jgitver/jgitver-maven-plugin/wiki/Intellij-IDEA-configuration).

--- a/openml-api/pom.xml
+++ b/openml-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>openml</artifactId>
         <groupId>com.feedzai</groupId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openml-example/pom.xml
+++ b/openml-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>openml</artifactId>
         <groupId>com.feedzai</groupId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openml-utils/pom.xml
+++ b/openml-utils/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>openml</artifactId>
         <groupId>com.feedzai</groupId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>com.feedzai</groupId>
     <artifactId>openml</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
This change uses [jgitver](https://github.com/jgitver/jgitver) for versioning which makes semantic versioning be calculated based only on git history instead of having to be manually merged everywhere. 