### PR TITLE
Improves one UT to verify that is possible to evaluate multiple events using the same model

### DIFF
--- a/openml-utils/src/test/java/com/feedzai/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/util/provider/AbstractProviderModelBaseTest.java
@@ -145,8 +145,9 @@ public abstract class AbstractProviderModelBaseTest<M extends ClassificationMLMo
 
     /**
      * Evaluates one model created (loaded/trained) in the main thread in multiple threads concurrently.
-     * The model will evaluate two types of instances, that will be injected at the same frequency (half of
-     * {@link #maxNumberOfThreads}).
+     * The model will evaluate two different instances, that will be injected at the same frequency (half of
+     * {@link #maxNumberOfThreads}). Afterwards, the results of the class distributions are asserted to verify that
+     * there are only two distinct results with the same frequency (half of {@link #maxNumberOfThreads}).
      *
      * @throws ModelLoadingException If anything goes wrong during loading.
      * @throws ModelTrainingException If anything goes wrong during training.


### PR DESCRIPTION
This commit improves the UT "createOneModelAndEvaluateInMultipleThreadsTest" to verify that an event is evaluated as expected (that is thread safe).

This test was improved to cover the failure discovered in R providers (https://github.com/feedzai/feedzai-openml-r/issues/17).