### PR TITLE
Refactor AbstractProviderModelBaseTest#createOneModelAndEvaluateInMultipleThreadsTest test

### DIFF
--- a/openml-utils/src/main/java/com/feedzai/openml/mocks/MockInstance.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/mocks/MockInstance.java
@@ -24,6 +24,7 @@ import com.feedzai.openml.data.schema.FieldSchema;
 import com.feedzai.openml.data.schema.NumericValueSchema;
 import com.feedzai.openml.data.schema.StringValueSchema;
 import com.feedzai.openml.util.data.ClassificationDatasetSchemaUtil;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 import java.io.Serializable;
@@ -110,6 +111,13 @@ public class MockInstance implements Instance, Serializable {
         }
         final MockInstance other = (MockInstance) obj;
         return Objects.equal(this.values, other.values);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("values", this.values)
+                .toString();
     }
 
     /**

--- a/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
@@ -25,11 +25,13 @@ import com.feedzai.openml.provider.exception.ModelTrainingException;
 import com.feedzai.openml.provider.model.MachineLearningModelLoader;
 import com.feedzai.openml.util.algorithm.MLAlgorithmEnum;
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -39,7 +41,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 
 import static junit.framework.TestCase.fail;
@@ -162,19 +166,14 @@ public abstract class AbstractProviderModelBaseTest<M extends ClassificationMLMo
         // Wait for all classifications to finish
         final List<double[]> classDistributionResults = getUnorderedClassificationResults(evaluationsList);
 
-        final List<Double> minClassificationValues = classDistributionResults.stream()
-                .mapToDouble(classDistArr -> Arrays.stream(classDistArr).min().getAsDouble())
-                .boxed()
-                .collect(Collectors.toList());
+        final Map<List<Double>, Long> groupedClassDistResults = classDistributionResults
+                .stream()
+                .map(arr -> Arrays.asList(ArrayUtils.toObject(arr)))
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 
-        minClassificationValues.stream()
-                .distinct()
-                .forEach(
-                        minValue ->
-                                assertThat(Collections.frequency(minClassificationValues, minValue))
-                                        .as("Minimum value of a classification result")
-                                        .isEqualTo(this.maxNumberOfThreads / 2)
-                );
+        groupedClassDistResults.forEach((key, count) -> assertThat(count)
+                .as(String.format("The number of times the classification %s should appear", key))
+                .isEqualTo(this.maxNumberOfThreads / 2));
     }
 
     /**

--- a/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
@@ -43,7 +43,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 
 import static junit.framework.TestCase.fail;


### PR DESCRIPTION
This commit aims to refactor one of the tests on the AbstractProviderModelBaseTest.
The createOneModelAndEvaluateInMultipleThreadsTest test had some logic not as obvious as
it could be (IMHO - let me know if you disagree with this opinion). While we wanted to
check the number of occurrences of each classDistrbution result (assuming
each instance would produce a different output), the code was looking at
the minimum value found. This changes tries to make more obvious the goal of
that assertion.

Also added a toString method to the MockInstance, useful for test debug.