### PR TITLE
Add pitest mutation test plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ branches:
     #hotfix branches (not being too strict on purpose)
     - /^hf-.*$/
 
+script:
+  - mvn test -B
+  - mvn org.pitest:pitest-maven:mutationCoverage
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
 
 script:
   - mvn test -B
-  - mvn org.pitest:pitest-maven:mutationCoverage
+  - mvn pitmp:run
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ Quality is validated in pull requests using [travis-ci.com](https://travis-ci.co
 The `script` phase of the Travis lifecycle will run tests which produce JaCoCo coverage reports that are in turn sent to [Codecov.io](https://codecov.io) for code coverage analysis.
 In parallel, Codacy runs static code analysis and displays it on [Codacy](https://app.codacy.com/app/feedzai/feedzai-openml/dashboard).
 
+This project uses Mutation Testing to ensure the quality of the testing suite. If your contribution is failing on that step, you should probably read the context and explanation available on the PR which introduced the technology: https://github.com/feedzai/feedzai-openml/pull/33.
+
 ## Merging
 Pull requests with failing builds will not be merged, and coverage is expected to be above 85%.
 Static code analysis issues will be evaluated ad-hoc, especially since it is common to have several warnings related to abstraction violations that need to be performed for performance reasons.

--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
@@ -23,9 +23,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -68,31 +65,22 @@ public class DatasetSchema implements Serializable {
     }
 
     /**
-     * Auxiliar method to check all the restrictions on the {@link FieldSchema} upon {@link DatasetSchema} creation.
+     * Auxiliary method to check all the restrictions on the {@link FieldSchema} upon {@link DatasetSchema} creation.
      *
      * @param fieldSchemas The List of field schemas.
      * @return The original list of field schemas if all the checks have passed. Otherwise
      * an {@link IllegalArgumentException} is thrown.
      */
-    private  List<FieldSchema> checkFieldSchemas(final List<FieldSchema> fieldSchemas) {
+    private List<FieldSchema> checkFieldSchemas(final List<FieldSchema> fieldSchemas) {
 
         Preconditions.checkNotNull(fieldSchemas, "field schemas should not be null");
 
         final List<Integer> indexes = fieldSchemas.stream().map(FieldSchema::getFieldIndex).collect(Collectors.toList());
 
-        // check if indexes unique
-        Preconditions.checkArgument(indexes.size() == new HashSet<>(indexes).size(),
-                                    "field schemas should have unique indexes");
-
-        // check if indexes are sorted
-        final ArrayList<Integer> sortedList = new ArrayList<>(indexes);
-        Collections.sort(sortedList);
-        Preconditions.checkArgument(sortedList.equals(indexes), "field schemas should be sorted by index");
-
-        // check if there are no missing indexes, i.e., all the indexes are continuous. Since we already check for
-        // sorting, if the first index is 0 and the last is indexes.size - 1, then we have that ensurance.
+        // check if indexes are a continuous list with no duplicated elements, i.e., all indexes are unique, are sorted
+        // and there are no intermediary indexes missing.
         Preconditions.checkArgument(indexes.equals(IntStream.range(0, indexes.size()).boxed().collect(Collectors.toList())),
-                                    "field schemas have missing intermediary indexes");
+                                    "field schemas be sorted by increasing index, with no duplicated nor missing elements");
 
         Preconditions.checkArgument(
                 fieldSchemas.size() == fieldSchemas.stream().map(FieldSchema::getFieldName).collect(Collectors.toSet()).size(),

--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/MLAlgorithmDescriptor.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/MLAlgorithmDescriptor.java
@@ -100,9 +100,10 @@ public class MLAlgorithmDescriptor {
     }
 
     /**
-     * Gets the URL pointing to the documentation about this algorithm.
+     * Gets the possible null URL pointing to the documentation about this algorithm.
      *
-     * @return The {@link URL} containing the documentation.
+     * @return The {@link URL} containing the documentation. Can be null if the received string representation was not
+     * a valid URL.
      */
     public URL getDocumentation() {
         return this.documentation;

--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/ChoiceFieldType.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/ChoiceFieldType.java
@@ -85,11 +85,9 @@ public class ChoiceFieldType implements ModelParameterType {
         if (this.allowedValues.contains(parameterValue)) {
             return Optional.empty();
         } else {
-            return Optional.of(
-                    new ParamValidationError(
-                            parameterName,
-                            parameterValue,
-                            "should be one of: " + this.allowedValues.stream().collect(Collectors.joining(", "))));
+            String reason = "should be one of: " + String.join(", ", this.allowedValues);
+
+            return Optional.of(new ParamValidationError(parameterName, parameterValue, reason));
         }
     }
 

--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/NumericFieldType.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/NumericFieldType.java
@@ -64,6 +64,7 @@ public class NumericFieldType implements ModelParameterType {
                              final ParameterConfigType parameterType,
                              final double defaultValue) {
 
+        Preconditions.checkArgument(minValue <= maxValue, "min value should be smaller or equal to max value");
         Preconditions.checkArgument(
                 defaultValue >= minValue && defaultValue <= maxValue,
                 "The default value must be within the min and max values."
@@ -71,7 +72,7 @@ public class NumericFieldType implements ModelParameterType {
 
         this.minValue = minValue;
         this.maxValue = maxValue;
-        this.parameterType = parameterType;
+        this.parameterType = Preconditions.checkNotNull(parameterType, "Parameter type can't be null");
         this.defaultValue = defaultValue;
     }
 
@@ -110,8 +111,6 @@ public class NumericFieldType implements ModelParameterType {
      * @return A new {@link NumericFieldType}.
      */
     public static NumericFieldType range(final double minValue, final double maxValue, final ParameterConfigType parameterType, final double defaultValue) {
-        Preconditions.checkArgument(minValue <= maxValue, "min value should be smaller than max value");
-
         return new NumericFieldType(minValue, maxValue, parameterType, defaultValue);
     }
 

--- a/openml-api/src/test/java/com/feedzai/openml/data/schema/CategoricalValueSchemaTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/data/schema/CategoricalValueSchemaTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -43,6 +44,16 @@ public class CategoricalValueSchemaTest {
      * Test nominal values to use.
      */
     private static final Set<String> NOMINAL_VALUES = ImmutableSet.of("val0", "val1");
+
+    /**
+     * Tests creating an instance with a nullable collection of values.
+     */
+    @Test
+    public void testNullValues() {
+        assertThatThrownBy(() -> new CategoricalValueSchema(true, null))
+                .as("The error thrown by an incorrect construction of a CategoricalValueSchema")
+                .isInstanceOf(NullPointerException.class);
+    }
 
     /**
      * Tests getting the nominal values.

--- a/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
@@ -175,7 +175,8 @@ public class DatasetSchemaTest {
 
         assertThatThrownBy(() -> new DatasetSchema(targetField.getFieldIndex(), allFields))
                 .as("The error thrown by an incorrect construction of a schema")
-                .isInstanceOf(IllegalArgumentException.class);    }
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 
     /**
      * Tests that the {@link FieldSchema} of the {@link DatasetSchema} don't have a missing intermediary index.

--- a/openml-api/src/test/java/com/feedzai/openml/provider/descriptor/ModelParameterTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/descriptor/ModelParameterTest.java
@@ -19,6 +19,8 @@ package com.feedzai.openml.provider.descriptor;
 
 import com.feedzai.openml.provider.descriptor.fieldtype.FreeTextFieldType;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,7 +30,24 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Nuno Diegues (nuno.diegues@feedzai.com)
  * @since 0.1.0
  */
+@RunWith(Parameterized.class)
 public class ModelParameterTest {
+
+    /**
+     * If the {@link ModelParameter} created during the test should be mandatory or not.
+     */
+    @Parameterized.Parameter
+    public boolean mandatory;
+
+    /**
+     * Sets up the test parameter, representing whether the created {@link ModelParameter} should be mandatory.
+     *
+     * @return An array of {@link Object} representing the possible values for {@link #mandatory}.
+     */
+    @Parameterized.Parameters
+    public static Object[] data() {
+        return new Object[] { true, false };
+    }
 
     /**
      * Tests for a valid parameter.
@@ -39,7 +58,7 @@ public class ModelParameterTest {
         final String paramName = "param1";
         final String descName = "desc1";
         final String help = "help1";
-        final boolean isMandatory = true;
+        final boolean isMandatory = this.mandatory;
         final FreeTextFieldType fieldType = new FreeTextFieldType("default");
 
         final ModelParameter modelParameter = new ModelParameter(paramName, descName, help, isMandatory, fieldType);
@@ -86,4 +105,6 @@ public class ModelParameterTest {
                 .isEqualTo(modelParameterClone.hashCode())
                 .isNotEqualTo(differentParam.hashCode());
     }
+
+
 }

--- a/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/AbstractConfigFieldTypeTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/AbstractConfigFieldTypeTest.java
@@ -103,10 +103,11 @@ abstract class AbstractConfigFieldTypeTest<T extends ModelParameterType> {
         final Optional<ParamValidationError> result = fieldType.validate(paramName, paramValue);
 
         assertEquals(
-                String.format("Param %s with value %s should %s",
+                String.format("Param %s with value %s should %s, error: %s",
                               paramName,
                               paramValue,
-                              expectsError ? "not be valid" : "be valid"),
+                              expectsError ? "not be valid" : "be valid",
+                              result.map(ParamValidationError::getMessage).orElse("")),
                 result.isPresent(),
                 expectsError);
     }

--- a/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/ChoiceFieldTypeTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/ChoiceFieldTypeTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests the behaviour of the {@link ChoiceFieldType} class.
@@ -41,6 +43,32 @@ public class ChoiceFieldTypeTest extends AbstractConfigFieldTypeTest<ChoiceField
     @Override
     ChoiceFieldType getAnotherInstance() {
         return new ChoiceFieldType(ImmutableSet.of("val1", "val2"), "val2");
+    }
+
+    /**
+     * Tests the constructor verifications for invalid values.
+     */
+    @Test
+    public void validateConstructor() {
+        assertThatThrownBy(() -> new ChoiceFieldType(null, "value2"))
+                .as("A ChoiceFieldType cannot have null 'allowedFields'")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new ChoiceFieldType(ImmutableSet.of("value1", "value2"), null))
+                .as("A ChoiceFieldType cannot have a null default value")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new ChoiceFieldType(ImmutableSet.of(), "value2"))
+                .as("A ChoiceFieldType cannot have an empty set of 'allowedFields'")
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> new ChoiceFieldType(ImmutableSet.of("value1", "value2"), "value3"))
+                .as("A ChoiceFieldType cannot have null a default value outside of allowed values")
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatCode(() -> new ChoiceFieldType(ImmutableSet.of("value1", "value2"), "value2"))
+                .as("A valid ChoiceFieldType constructor")
+                .doesNotThrowAnyException();
     }
 
     /**

--- a/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/NumericFieldTypeTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/NumericFieldTypeTest.java
@@ -21,6 +21,8 @@ import com.feedzai.openml.provider.descriptor.fieldtype.NumericFieldType;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests the behaviour of the {@link NumericFieldType} class.
@@ -62,13 +64,17 @@ public class NumericFieldTypeTest extends AbstractConfigFieldTypeTest<NumericFie
                 defaultValue
         );
 
-        assertValidationResult(fieldType, "param0", null, true);
-        assertValidationResult(fieldType, "param1", "", true);
-        assertValidationResult(fieldType, "param2", "non-parsable", true);
-        assertValidationResult(fieldType, "param3", String.valueOf(minValue - 1), true);
-        assertValidationResult(fieldType, "param4", String.valueOf(maxValue + 1), true);
-        assertValidationResult(fieldType, "param5", String.valueOf(minValue + 1), false);
+        assertValidationResult(fieldType, "param", null, true);
+        assertValidationResult(fieldType, "param", "", true);
+        assertValidationResult(fieldType, "param", "non-parsable", true);
 
+        assertValidationResult(fieldType, "param", String.valueOf(minValue - 1), true);
+        assertValidationResult(fieldType, "param", String.valueOf(minValue), false);
+        assertValidationResult(fieldType, "param", String.valueOf(minValue + 1), false);
+
+        assertValidationResult(fieldType, "param", String.valueOf(maxValue - 1), false);
+        assertValidationResult(fieldType, "param", String.valueOf(maxValue), false);
+        assertValidationResult(fieldType, "param", String.valueOf(maxValue + 1), true);
     }
 
     /**
@@ -92,6 +98,49 @@ public class NumericFieldTypeTest extends AbstractConfigFieldTypeTest<NumericFie
 
         assertThat(type1.getParameterType())
                 .isEqualTo(NumericFieldType.ParameterConfigType.DOUBLE);
+    }
+
+    /**
+     * Tests the constructor verifications for invalid values.
+     */
+    @Test
+    public void validateConstructor() {
+
+        assertThatThrownBy(() ->  NumericFieldType.range(-1, 1, null, 0))
+                .as("A NumericFieldType cannot have a null parameter type")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> NumericFieldType.range(1, -1, NumericFieldType.ParameterConfigType.DOUBLE, 1))
+                .as("The min value cannot be bigger than the max value")
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatCode(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, 0))
+                .as("A valid NumericFieldType constructor")
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> NumericFieldType.range(-1, -1, NumericFieldType.ParameterConfigType.DOUBLE, -1))
+                .as("A  NumericFieldType with a max value equal to min")
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, -1))
+                .as("A  NumericFieldType with a default value equal to min")
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, 0))
+                .as("A  NumericFieldType with a default value between min and max")
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, 1))
+                .as("A  NumericFieldType with a default value equal to max")
+                .doesNotThrowAnyException();
+
+        assertThatThrownBy(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, -2))
+                .as("A  NumericFieldType with a default value smaller than min")
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, 2))
+                .as("A  NumericFieldType with a default value bigger than max")
+                .isInstanceOf(IllegalArgumentException.class);
 
     }
 

--- a/openml-utils/src/main/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnum.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnum.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.feedzai.openml.provider.descriptor.MLAlgorithmDescriptor;
 import com.feedzai.openml.provider.descriptor.MachineLearningAlgorithmType;
 import com.feedzai.openml.provider.descriptor.ModelParameter;
+import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,11 +59,15 @@ public interface MLAlgorithmEnum {
                                                   final Set<ModelParameter> algorithmParameters,
                                                   final MachineLearningAlgorithmType algorithmType,
                                                   final String documentationLink) {
+
+        Preconditions.checkNotNull(documentationLink, "The documentation link should not be null");
+
         URL documentationUrl = null;
         try {
             documentationUrl = new URL(documentationLink);
         } catch (final MalformedURLException e) {
             logger.warn(String.format("The documentation URL for the algorithm descriptor '%s' is malformed", algorithmName), e);
+            throw new IllegalArgumentException(String.format("Supplied documentation link is not a valid URL: %s", e.getMessage()));
         }
 
         return new MLAlgorithmDescriptor(

--- a/openml-utils/src/main/java/com/feedzai/openml/util/data/encoding/EncodingHelper.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/data/encoding/EncodingHelper.java
@@ -107,7 +107,7 @@ public final class EncodingHelper implements Serializable {
             return value -> (Double) handleNullOrFailed(value, function, DEFAULT_CATEGORICAL_VALUE);
 
         } else {
-            final SerializableEncoder function = Object::toString;
+            final SerializableEncoder function = s -> s;
             return value -> (String) handleNullOrFailed(value, function, DEFAULT_STRING_VALUE);
         }
     }

--- a/openml-utils/src/main/java/com/feedzai/openml/util/validate/ValidationUtils.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/validate/ValidationUtils.java
@@ -187,18 +187,6 @@ public final class ValidationUtils {
             errorBuilder.add(new ParamValidationError("The map of parameters cannot be null"));
         }
 
-        if (Objects.isNull(schema.getFieldSchemas())) {
-            errorBuilder.add(new ParamValidationError("field schemas cannot be null"));
-        }
-
-        if (schema.getTargetIndex() < 0) {
-            errorBuilder.add(new ParamValidationError("target index cannot be negative"));
-        }
-
-        if (schema.getFieldSchemas().size() <= schema.getTargetIndex()) {
-            errorBuilder.add(new ParamValidationError("target index should not be bigger than the size of the fields"));
-        }
-
         return errorBuilder.build();
     }
 

--- a/openml-utils/src/test/java/com/feedzai/openml/mocks/MockInstanceTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/mocks/MockInstanceTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.feedzai.openml.mocks;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Class that tests the behaviour of an {@link MockInstance}.
+ *
+ * @since @@@feedzai.next.release@@@
+ * @author Pedro Rijo (pedro.rijo@feedzai.com)
+ */
+public class MockInstanceTest {
+
+    /**
+     * Tests the construction through {@link MockInstance#MockInstance(double[])}.
+     */
+    @Test
+    public void testDoubleArray() {
+
+        final double[] doubles = {0, 1, 2};
+
+        final MockInstance instance = new MockInstance(doubles);
+
+        final List<Double> values = Arrays.stream(doubles).boxed().collect(Collectors.toList());
+
+        values.forEach(idx -> {
+            assertThat(instance.getValue(idx.intValue()))
+                    .as("The instance value")
+                    .isEqualTo(idx);
+
+            assertThatThrownBy(() -> instance.getStringValue(idx.intValue()))
+                    .as("The instance string value")
+                    .isInstanceOf(ClassCastException.class);
+        });
+
+    }
+
+    /**
+     * Tests the construction through {@link MockInstance#MockInstance(List)}.
+     */
+    @Test
+    public void testList() {
+
+        final List<Serializable> values = ImmutableList.of("0", "1", "2");
+        final MockInstance instance = new MockInstance(values);
+
+        values.forEach(idx -> {
+            assertThat(instance.getStringValue(Integer.parseInt((String) idx)))
+                    .as("The instance string value")
+                    .isEqualTo(idx);
+
+            assertThatThrownBy(() -> instance.getValue(Integer.parseInt((String) idx)))
+                    .as("The instance value")
+                    .isInstanceOf(ClassCastException.class);
+        });
+
+    }
+
+
+    /**
+     * Tests the construction through {@link MockInstance#MockInstance(int, Random)}.
+     */
+    @Test
+    public void testSize() {
+        final int numberFieldsSize = 10;
+        final MockInstance instance = new MockInstance(numberFieldsSize, new Random());
+
+        IntStream.range(0, numberFieldsSize).forEach(idx -> assertThatCode(() -> instance.getValue(idx))
+                .as("The instance value for valid index")
+                .doesNotThrowAnyException());
+
+        assertThatThrownBy(() -> instance.getValue(numberFieldsSize))
+                .as("The instance value for an index bigger than asked")
+                .isInstanceOf(IndexOutOfBoundsException.class);
+
+    }
+
+}

--- a/openml-utils/src/test/java/com/feedzai/openml/util/ClassificationDatasetSchemaUtilTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/ClassificationDatasetSchemaUtilTest.java
@@ -17,15 +17,14 @@
 
 package com.feedzai.openml.util;
 
-import com.feedzai.openml.data.schema.CategoricalValueSchema;
-import com.feedzai.openml.data.schema.DatasetSchema;
-import com.feedzai.openml.data.schema.FieldSchema;
-import com.feedzai.openml.data.schema.NumericValueSchema;
+import com.feedzai.openml.data.schema.*;
 import com.feedzai.openml.util.data.ClassificationDatasetSchemaUtil;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -69,6 +68,30 @@ public class ClassificationDatasetSchemaUtilTest {
         assertThatThrownBy(() -> ClassificationDatasetSchemaUtil.getNumClassValues(datasetSchema))
                 .as("The error for not having a categorical target")
                 .isInstanceOf(RuntimeException.class);
+    }
+
+    /**
+     * Tests the behaviour of {@link ClassificationDatasetSchemaUtil#withCategoricalValueSchema(AbstractValueSchema, Function)}.
+     */
+    @Test
+    public void testWithCategoricalSchema() {
+
+        final Integer returnValue = 10;
+
+        final Function<CategoricalValueSchema, Integer> fun = (categoricalValueSchema -> returnValue);
+
+        assertThat(ClassificationDatasetSchemaUtil.withCategoricalValueSchema(new NumericValueSchema(true), fun))
+                .as("The output of calling withCategoricalValueSchema on a NumericValueSchema")
+                .isEmpty();
+
+        assertThat(ClassificationDatasetSchemaUtil.withCategoricalValueSchema(new StringValueSchema(true), fun))
+                .as("The output of calling withCategoricalValueSchema on a StringValueSchema")
+                .isEmpty();
+
+        assertThat(ClassificationDatasetSchemaUtil.withCategoricalValueSchema(new CategoricalValueSchema(true, ImmutableSet.of()), fun))
+                .as("The output of calling withCategoricalValueSchema on a CategoricalValueSchema")
+                .isNotEmpty()
+                .contains(returnValue);
     }
 
     /**

--- a/openml-utils/src/test/java/com/feedzai/openml/util/algorithm/DummyAlgorithmEnum.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/algorithm/DummyAlgorithmEnum.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.feedzai.openml.util.algorithm;
+
+import com.feedzai.openml.provider.descriptor.MLAlgorithmDescriptor;
+import com.feedzai.openml.provider.descriptor.MachineLearningAlgorithmType;
+import com.google.common.collect.ImmutableSet;
+
+public enum DummyAlgorithmEnum implements MLAlgorithmEnum {
+
+    /**
+     * Default Classification algorithm used for all Scikit-learn models.
+     */
+    DUMMY(MLAlgorithmEnum.createDescriptor(
+            "Classification Algorithm",
+            ImmutableSet.of(),
+            MachineLearningAlgorithmType.MULTI_CLASSIFICATION,
+            "https://feedzai.com/"
+    ));
+
+    /**
+     * {@link MLAlgorithmDescriptor} for this algorithm.
+     */
+    public final MLAlgorithmDescriptor descriptor;
+
+    /**
+     * Constructor.
+     *
+     * @param descriptor {@link MLAlgorithmDescriptor} for this algorithm.
+     */
+    DummyAlgorithmEnum(final MLAlgorithmDescriptor descriptor) {
+        this.descriptor = descriptor;
+    }
+
+    @Override
+    public MLAlgorithmDescriptor getAlgorithmDescriptor() {
+        return this.descriptor;
+    }
+}

--- a/openml-utils/src/test/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnumTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnumTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2018 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.feedzai.openml.util.algorithm;
+
+import com.feedzai.openml.provider.descriptor.MLAlgorithmDescriptor;
+import com.feedzai.openml.provider.descriptor.MachineLearningAlgorithmType;
+import com.feedzai.openml.provider.descriptor.ModelParameter;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Class to test the behaviour of {@link MLAlgorithmEnum}.
+ *
+ * @since @@@feedzai.next.release@@@
+ * @author Pedro Rijo (pedro.rijo@feedzai.com)
+ */
+public class MLAlgorithmEnumTest {
+
+    /**
+     * Tests the {@link MLAlgorithmEnum#createDescriptor(String, Set, MachineLearningAlgorithmType, String)} with
+     * a valid input.
+     */
+    @Test
+    public void testCreateDescriptor() {
+        final String algoName = "algoName";
+        final ImmutableSet<ModelParameter> parameters = ImmutableSet.of();
+        final MachineLearningAlgorithmType algorithmType = MachineLearningAlgorithmType.BINARY_CLASSIFICATION;
+        final String documentationLink = "https://feedzai.com/";
+
+        final MLAlgorithmDescriptor descriptor = MLAlgorithmEnum.createDescriptor(algoName, parameters, algorithmType, documentationLink);
+
+        assertThat(descriptor.getAlgorithmName())
+                .as("The descriptor algorithm name")
+                .isEqualTo(algoName);
+
+        assertThat(descriptor.getParameters())
+                .as("The descriptor parameters")
+                .isEqualTo(parameters);
+
+        assertThat(descriptor.getAlgorithmType())
+                .as("The descriptor algorithm type")
+                .isEqualTo(algorithmType);
+
+        assertThat(descriptor.getDocumentation().toString())
+                .as("The descriptor documentation URL")
+                .isEqualTo(documentationLink);
+
+    }
+
+    /**
+     * Tests the {@link MLAlgorithmEnum#createDescriptor(String, Set, MachineLearningAlgorithmType, String)} with
+     * an invalid input.
+     */
+    @Test
+    public void testInvalidCreateDescriptor() {
+        final String algoName = "algoName";
+        final ImmutableSet<ModelParameter> parameters = ImmutableSet.of();
+        final MachineLearningAlgorithmType algorithmType = MachineLearningAlgorithmType.BINARY_CLASSIFICATION;
+        final String documentationLink = "https://feedzai.com/";
+
+        assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(null, parameters, algorithmType, documentationLink))
+                .as("The exception throw by trying to create a descriptor with null algorithm name")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, null, algorithmType, documentationLink))
+                .as("The exception throw by trying to create a descriptor with null algorithm params")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, parameters, null, documentationLink))
+                .as("The exception throw by trying to create a descriptor with null algorithm type")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, parameters, algorithmType, null))
+                .as("The exception throw by trying to create a descriptor with null URL")
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    /**
+     * Tests the {@link MLAlgorithmEnum#createDescriptor(String, Set, MachineLearningAlgorithmType, String)} with
+     * an invalid URL.
+     */
+    @Test
+    public void testInvalidUrl() {
+        final String algoName = "algoName";
+        final ImmutableSet<ModelParameter> parameters = ImmutableSet.of();
+        final MachineLearningAlgorithmType algorithmType = MachineLearningAlgorithmType.BINARY_CLASSIFICATION;
+
+        assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, parameters, algorithmType, "random string"))
+                .as("The exception throw by trying to create a descriptor with an invalid URL")
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /**
+     * Tests the {@link MLAlgorithmEnum#getName}.
+     */
+    @Test
+    public void testGetName() {
+        assertThat(DummyAlgorithmEnum.DUMMY.getName())
+                .as("The dummy algorithm name")
+                .isEqualTo(DummyAlgorithmEnum.DUMMY.getAlgorithmDescriptor().getAlgorithmName());
+    }
+
+    /**
+     * Tests the {@link MLAlgorithmEnum#getDescriptors(MLAlgorithmEnum[])}.
+     */
+    @Test
+    public void testGetDescriptors() {
+        final Set<MLAlgorithmDescriptor> descriptors = MLAlgorithmEnum.getDescriptors(DummyAlgorithmEnum.values());
+
+        assertThat(descriptors)
+                .as("The number of descriptors")
+                .hasSize(DummyAlgorithmEnum.values().length);
+
+        assertThat(descriptors)
+                .as("The descriptors returned by the auxiliary method")
+                .isEqualTo(Stream.of(DummyAlgorithmEnum.values()).map(DummyAlgorithmEnum::getAlgorithmDescriptor).collect(Collectors.toSet()));
+    }
+
+    /**
+     * Tests the {@link MLAlgorithmEnum#getByName(MLAlgorithmEnum[], String)}.
+     */
+    @Test
+    public void testGetByName() {
+        assertThat(MLAlgorithmEnum.getByName(DummyAlgorithmEnum.values(), null))
+                .as("The get by name for null argument")
+                .isEmpty();
+
+        assertThat(MLAlgorithmEnum.getByName(DummyAlgorithmEnum.values(), "random name"))
+                .as("The get by name for an unexisting name")
+                .isEmpty();
+
+        assertThat(MLAlgorithmEnum.getByName(DummyAlgorithmEnum.values(), DummyAlgorithmEnum.DUMMY.getName()))
+                .as("The get by name for an existing name")
+                .isPresent()
+                .contains(DummyAlgorithmEnum.DUMMY);
+
+    }
+
+}

--- a/openml-utils/src/test/java/com/feedzai/openml/util/data/encoding/EncodingHelperTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/data/encoding/EncodingHelperTest.java
@@ -17,6 +17,7 @@
 
 package com.feedzai.openml.util.data.encoding;
 
+import com.feedzai.openml.data.schema.AbstractValueSchema;
 import com.feedzai.openml.data.schema.CategoricalValueSchema;
 import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.data.schema.FieldSchema;
@@ -41,6 +42,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @since 0.1.0
  */
 public class EncodingHelperTest {
+
+    /**
+     * Tests the behaviour of the {@link EncodingHelper} constructor with null arguments.
+     */
+    @Test
+    public void testNull() {
+        assertThatThrownBy(() -> new EncodingHelper(null))
+                .as("The error thrown by an incorrect construction of a CategoricalValueSchema")
+                .isInstanceOf(NullPointerException.class);
+    }
 
     /**
      * Tests the encoding of different types of schema fields.
@@ -220,6 +231,30 @@ public class EncodingHelperTest {
 
         assertThat(encodingHelper.encode("ERROR", fieldIndex))
                 .as("Encoding a string")
+                .isEqualTo(Double.NaN);
+    }
+
+    /**
+     * Tests the existing encoders from {@link EncodingHelper#encoderForField(AbstractValueSchema)}.
+     */
+    @Test
+    public void testEncodersOnNulls() {
+        final NumericValueSchema numericValueSchema = new NumericValueSchema(true);
+        final EncodingHelper.SerializableEncoder numericEncoder = EncodingHelper.encoderForField(numericValueSchema);
+        assertThat(numericEncoder.apply(null))
+                .as("The result of applying the numeric encoder to a null")
+                .isEqualTo(Double.NaN);
+
+        final StringValueSchema stringValueSchema = new StringValueSchema(true);
+        final EncodingHelper.SerializableEncoder stringEncoder = EncodingHelper.encoderForField(stringValueSchema);
+        assertThat(stringEncoder.apply(null))
+                .as("The result of applying the string encoder to a null")
+                .isEqualTo(null);
+
+        final CategoricalValueSchema categoricalSchema = new CategoricalValueSchema(true, ImmutableSet.of());
+        final EncodingHelper.SerializableEncoder categoricalEncoder = EncodingHelper.encoderForField(categoricalSchema);
+        assertThat(categoricalEncoder.apply(null))
+                .as("The result of applying the categorical encoder to a null")
                 .isEqualTo(Double.NaN);
     }
 }

--- a/openml-utils/src/test/java/com/feedzai/openml/util/load/LoadSchemaUtilsTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/load/LoadSchemaUtilsTest.java
@@ -17,11 +17,17 @@
 
 package com.feedzai.openml.util.load;
 
+import com.feedzai.openml.data.schema.AbstractValueSchema;
+import com.feedzai.openml.data.schema.CategoricalValueSchema;
 import com.feedzai.openml.data.schema.DatasetSchema;
+import com.feedzai.openml.data.schema.NumericValueSchema;
+import com.feedzai.openml.data.schema.StringValueSchema;
 import com.feedzai.openml.provider.exception.ModelLoadingException;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -54,10 +60,43 @@ public class LoadSchemaUtilsTest {
      * Tests that when there is an error with the json file it will return an empty optional.
      */
     @Test
-    public void notExistTest() {
+    public void dirNotExistTest() {
         assertThatThrownBy(() -> LoadSchemaUtils.datasetSchemaFromJson(Paths.get("dummy")))
                 .as("the dataset schema doesn't exist")
                 .hasMessageContaining("The path")
                 .hasMessageContaining("should be a directory");
+    }
+
+    /**
+     * Tests the behaviour of {@link LoadSchemaUtils#datasetSchemaFromJson(Path)} when the folder doesn't contain
+     * the model.json file.
+     */
+    @Test
+    public void jsonNotExistTest() {
+        final String directoryPath = getClass().getResource(File.separator + "wrong_model_000").getPath();
+
+        assertThatThrownBy(() -> LoadSchemaUtils.datasetSchemaFromJson(Paths.get(directoryPath)))
+                .as("The exception thrown by loading the schema from a path without the model.json file")
+                .isInstanceOf(ModelLoadingException.class)
+                .hasMessageContaining("model.json ");
+    }
+
+    /**
+     * Tests {@link LoadSchemaUtils#getValueSchemaTypeToString(AbstractValueSchema)}.
+     */
+    @Test
+    public void valueSchemaToString() {
+
+        assertThat(LoadSchemaUtils.getValueSchemaTypeToString(new StringValueSchema(true)))
+                .as("The string representation of a StringValueSchema")
+                .isEqualTo(LoadSchemaUtils.STRING);
+
+        assertThat(LoadSchemaUtils.getValueSchemaTypeToString(new CategoricalValueSchema(true, ImmutableSet.of())))
+                .as("The string representation of a CategoricalValueSchema")
+                .isEqualTo(LoadSchemaUtils.CATEGORICAL);
+
+        assertThat(LoadSchemaUtils.getValueSchemaTypeToString(new NumericValueSchema(true)))
+                .as("The string representation of a NumericValueSchema")
+                .isEqualTo(LoadSchemaUtils.NUMERIC);
     }
 }

--- a/openml-utils/src/test/java/com/feedzai/openml/util/validate/ValidationUtilsTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/validate/ValidationUtilsTest.java
@@ -53,6 +53,34 @@ public class ValidationUtilsTest {
     }
 
     /**
+     * Tests that {@link ValidationUtils#baseLoadValidations(DatasetSchema, Map)} can return some errors.
+     */
+    @Test
+    public void testBaseValidationErrors() {
+
+        final DatasetSchema schema = TestDatasetSchemaBuilder.builder()
+                .withCategoricalFields(3)
+                .withNumericalFields(3)
+                .withStringFields(3)
+                .build();
+
+        assertThat(ValidationUtils.baseLoadValidations(null, ImmutableMap.of("param1", "val1")))
+                .as("The list of errors found with a null schema")
+                .isNotEmpty()
+                .hasSize(1);
+
+        assertThat(ValidationUtils.baseLoadValidations(schema, null))
+                .as("The list of errors found with null parameters")
+                .isNotEmpty()
+                .hasSize(1);
+
+        assertThat(ValidationUtils.baseLoadValidations(null, null))
+                .as("The list of errors found with all arguments as null")
+                .isNotEmpty()
+                .hasSize(2);
+    }
+
+    /**
      * Tests that the {@link ValidationUtils#checkNoFieldsOfType(DatasetSchema, Class)} does not return errors when
      * searching for categorical fields in a schema without categoricals.
      */

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,7 @@
                         <param>equals</param>
                     </excludedMethods>
                     <mutationThreshold>78</mutationThreshold>
+		    <withHistory>true</withHistory>
                     <threads>2</threads>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
         <slf4j.version>1.7.25</slf4j.version>
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
-        <pitest.version>1.4.0</pitest.version>
     </properties>
 
     <dependencyManagement>
@@ -145,11 +144,6 @@
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.pitest</groupId>
-                <artifactId>pitest-maven</artifactId>
-                <version>${pitest.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -254,10 +248,13 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.pitest</groupId>
-                <artifactId>pitest-maven</artifactId>
-                <version>${pitest.version}</version>
+                <groupId>eu.stamp-project</groupId>
+                <artifactId>pitmp-maven-plugin</artifactId>
+                <version>1.3.4</version>
                 <configuration>
+                    <skippedModules>
+                        <param>openml-example</param>
+                    </skippedModules>
                     <mutateStaticInitializers>true</mutateStaticInitializers>
                     <mutators>
                         <mutator>ALL</mutator>
@@ -268,14 +265,9 @@
                         <param>hashCode</param>
                         <param>equals</param>
                     </excludedMethods>
-                    <mutationThreshold>55</mutationThreshold>
+                    <mutationThreshold>78</mutationThreshold>
                     <threads>2</threads>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>eu.stamp-project</groupId>
-                <artifactId>pitmp-maven-plugin</artifactId>
-                <version>1.3.4</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -259,10 +259,16 @@
                 <version>${pitest.version}</version>
                 <configuration>
                     <mutateStaticInitializers>true</mutateStaticInitializers>
-                    <mutationThreshold>55</mutationThreshold>
                     <mutators>
                         <mutator>ALL</mutator>
                     </mutators>
+                    <excludedMethods>
+                        <param>toString</param>
+                        <param>toStringHelper</param>
+                        <param>hashCode</param>
+                        <param>equals</param>
+                    </excludedMethods>
+                    <mutationThreshold>55</mutationThreshold>
                     <threads>2</threads>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -259,10 +259,11 @@
                 <version>${pitest.version}</version>
                 <configuration>
                     <mutateStaticInitializers>true</mutateStaticInitializers>
-                    <mutationThreshold>50</mutationThreshold>
+                    <mutationThreshold>55</mutationThreshold>
                     <mutators>
                         <mutator>ALL</mutator>
                     </mutators>
+                    <threads>2</threads>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
+        <pitest.version>1.4.0</pitest.version>
     </properties>
 
     <dependencyManagement>
@@ -144,6 +145,11 @@
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>${pitest.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -246,6 +252,23 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>${pitest.version}</version>
+                <configuration>
+                    <mutateStaticInitializers>true</mutateStaticInitializers>
+                    <mutationThreshold>50</mutationThreshold>
+                    <mutators>
+                        <mutator>ALL</mutator>
+                    </mutators>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>eu.stamp-project</groupId>
+                <artifactId>pitmp-maven-plugin</artifactId>
+                <version>1.3.4</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This is an WIP experiment, which consists in adding the [pitest mutation testing framework](http://pitest.org/) into the codebase.

# What is mutation testing?

Mutation testing may work as a better technique for validating the effectiveness of the existing tests. 

Our current approach (and the industry standard) has been to use LoC coverage (a few use alternative metrics like function coverage, branch coverage, statement coverage, and etc - more on the subject at https://blog.codacy.com/what-your-mother-didnt-tell-you-about-code-coverage-605253143936#9699). Nevertheless, (LoC) code coverage only measures how many lines of code have been executed during the test execution. This means it's possible to have 100% LoC coverage, and the tests may be "weak" as it may not assert the right properties (or the developer may even forget to assert something on the test). On the other hand, mutation testing changes (mutates) the source code and checks if the tests capture the behaviour change. A classic example is changing some `if` statement by reverting its condition:

```
public long factorial(int n) {
  if (n <= 1) {
    return 1;   
  } else {    
    return(n * factorial(n-1));  
  }
}
```

gets mutated into

```
public long factorial(int n) {
  if (n > 1) { // note the condition was mutated
    return 1;   
  } else {    
    return(n * factorial(n-1));  
  }
}
```
If no test fails after this change, then there's something to improve on the tests. By introducing this framework we hope to improve our tests and decrease the possible bugs.

Note that by its definition itself, mutation testing may be slow since it implies run the test suite after introducing each mutation (or group of mutations)

# PR structure

This PR is still WIP, and aims to bring the following changes:

- [x] Add pitest plugin
- [x] Add pitest phase to CI
- [x] Use framework report to improve the codebase 
- [x] Add documentation on README for developers wanting to contribute

# Did pitest found any code problem already?

Well, if it hadn't, this PR wouldn't exist :)

The first finding of pitest was that we have somehow redundant verifications on our codebase: https://github.com/feedzai/feedzai-openml/blob/master/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java#L87-L95

While the lines 87-90 only check the indexes are sorted, the lines 92-95 implicitly check the indexes are sorted because it compares the list of indexes with the range `0 until indexes.size()`, a comparison that would fail if the indexes weren't sorted.

Another example caught: NumericFieldTypeTest is not testing boundary values at https://github.com/feedzai/feedzai-openml/blob/master/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/NumericFieldTypeTest.java#L65-L70

by mutating `if (parsedValue < this.minValue)` into `if (parsedValue <= this.minValue)` at https://github.com/feedzai/feedzai-openml/blob/master/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/NumericFieldType.java#L164 , the tests still pass. Why are not ensuring the `minValue` is allowed on our tests? :)

Really sure more dangerous cases will appear in the report (hadn't the time to look at everything since some cases are still being reported even if they aren't very relevant - see `failing builds` topic bello)

# Implementation details

1. failing builds

It's possible to introduce a threshold for which the build phase would fail (useful for CI): http://pitest.org/quickstart/maven/#mutationthreshold

I would like to try 100% mutation testing coverage, but I'm not sure if possible, at least for now. I've seen a few reports complaining on `hashcode`/`equals`/`toString` methods not being properly tested, but I don't seem much value on that.

There's also a configuration to disable specific methods and classes that I need to try: 

- http://pitest.org/quickstart/maven/#excludedmethods 
- http://pitest.org/quickstart/maven/#excludedclasses
- http://pitest.org/quickstart/maven/#avoidcallsto

:warning: Still needs work (currently at 50% threshold) 

2. selected mutations

I'm starting by enabling [all mutations](http://pitest.org/quickstart/maven/#mutators), but may decrease the list of mutations if we get some irrelevant results.

3. multi module projects

The pitest framework has a problem dealing with multi module maven projects.
The solution [presented](http://pitest.org/quickstart/maven/#handling-projects-composed-of-mutiple-maven-modules-pitmp) is to rely on the [pitmp-maven-plugin](https://github.com/STAMP-project/pitmp-maven-plugin).

To execute the mutation test just use the following command on the project root (it's also possible to run in one of the submodules root):

`mvn org.pitest:pitest-maven:mutationCoverage`

and check the report on the `target` folder (inside a `pit-reports` folder)

4. run mutation testing over the last commit

There's a command to run the framework on recent changes, which will probably be used to run on CI, but I still need to have a better look: http://pitest.org/quickstart/maven/#scmmutationcoverage-goal

**Edit:** the referred configuration it seems to be an option to run mutation testing before commit/push, and not to run over a PR on CI, so it is not very useful for now

5. parallelism 

It is possible to configure the number of threads to use when mutation testing using the [threads configuration](http://pitest.org/quickstart/maven/#threads). By default uses a single thread.

In a very rough experiment on my mac (we can't even call it benchmark):

* 1 thread takes 42s
* 2 threads take 34s
* 4 threads take 34s
* 8 threads take 34s

6. incremental analysis

For very large codebases there's an *experimental* feature on pitest: [incremental analysis](http://pitest.org/quickstart/incremental_analysis/) which optimises the runs by tracking changes to the code and tests and storing the results from previous runs. But it doesn't seem a very safe option for now. Will only have a look at it if the mutation testing phase starts taking too long

# How to read PIT reports

Let's take as the base for the explanation the current top commit of this PR (https://github.com/feedzai/feedzai-openml/pull/33/commits/929f1d191efe5397f1b8a2b459c928aec4f4b7ca), and look into the `openml-api` submodule.

We first need to have the code compiled:

```
$ mvn clean install -DskipTests
```

Now we can run the mutation testing:

```
$ mvn org.pitest:pitest-maven:mutationCoverage
```

and this will generate a `feedzai-openml/openml-api/target/pit-reports` folder. Nested, there will be another folder whose name corresponds to the datetime the mutation test maven goal was run (for instance `201808232236` -> 2018/08/23 22h36m). Here's the report you should have generated: https://files.feedzai.com/index.php/s/Jy5iJQLCMeiPXEm

My advise is to open the `index.html` file, where you will be able to see the overall line coverage and mutation coverage scores, as well as the breakdown by package. Let's have a look at the package `com.feedzai.openml.provider.descriptor.fieldtype` and select the `NumericFieldType.java` since it has 100% line coverage and 77% mutation coverage.

You will see each line may have 1 of 5 different background colors:

- no background color (white): usually comments, fields, and other non-testable lines
- light green: code with line coverage but no mutation was generated by that line (the method was ignored on the mutation testing framework config)
- stronger green: code with mutation testing coverage that passed (all the generated mutations were detected by the test suite 👍)
- light red/pink: no line coverage for this line. This means no test goes through the line while executing
- stronger red/pink: code without mutation testing. This means at least one of the generated mutations was not detected by the test suite 👎

On the left of the line there's the line number, and in lines with mutations generated, there's a number (total number of mutations generated to that line). On hover, a popup will appear with details on the mutations, explaining the change introduced by the mutation, and if the mutation survived (👎) or was killed (👍)

On line 113 of `NumericFieldType.java` report, we can see that the mutation coverage is not ok. There were generated 7 mutations, and 4 of them survived:

```
1. range : changed conditional boundary → SURVIVED
2. range : Substituted 0 with 1 → SURVIVED
3. range : removed conditional - replaced comparison check with true → SURVIVED
4. range : removed call to com/google/common/base/Preconditions::checkArgument → SURVIVED
5. range : Substituted 1 with 0 → KILLED
6. range : negated conditional → KILLED
7. range : removed conditional - replaced comparison check with false → KILLED
```

How to find the problem? Well, typically the explanation is somehow intuitive. 

1. The first mutation changed the conditional boundary which typically means the comparison operator had the equality added/removed (`<=` mutated into `<`).
2. This mutation is not as obvious because we wonder where is the `0`, but (and I'm not 100% sure, but it was the info I found at the time) there is a specific test where the method is called with one of the arguments as 0 (probably the `minValue`) and it was replaced by 1.
3. The third mutation changed the boolean expression into a constant value `true`
4. The last survived mutation is all about removing the line itself.

This means we need to have better tests on which values are allowed for this method. The improvement was introduced on https://github.com/feedzai/feedzai-openml/pull/34/files#diff-e49ec2f12a587bdb6dcc4aa89ffb357b

Most of the surviving mutations of this project are similar to these 4 examples: boolean expressions replaced by constant, deleted lines, boundaries changed.