### PR TITLE
Fixes from mutation testing report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ branches:
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
     #hotfix branches (not being too strict on purpose)
     - /^hf-.*$/
-    - exp/mutationTesting-pimp
 
 script:
   - mvn test -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
 
 script:
   - mvn test -B
-  - mvn org.pitest:pitest-maven:mutationCoverage
+  - mvn pitmp:run
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
     #hotfix branches (not being too strict on purpose)
     - /^hf-.*$/
+    - exp/mutationTesting-pimp
 
 script:
   - mvn test -B

--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
@@ -68,13 +68,13 @@ public class DatasetSchema implements Serializable {
     }
 
     /**
-     * Auxiliar method to check all the restrictions on the {@link FieldSchema} upon {@link DatasetSchema} creation.
+     * Auxiliary method to check all the restrictions on the {@link FieldSchema} upon {@link DatasetSchema} creation.
      *
      * @param fieldSchemas The List of field schemas.
      * @return The original list of field schemas if all the checks have passed. Otherwise
      * an {@link IllegalArgumentException} is thrown.
      */
-    private  List<FieldSchema> checkFieldSchemas(final List<FieldSchema> fieldSchemas) {
+    private List<FieldSchema> checkFieldSchemas(final List<FieldSchema> fieldSchemas) {
 
         Preconditions.checkNotNull(fieldSchemas, "field schemas should not be null");
 

--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
@@ -80,19 +80,10 @@ public class DatasetSchema implements Serializable {
 
         final List<Integer> indexes = fieldSchemas.stream().map(FieldSchema::getFieldIndex).collect(Collectors.toList());
 
-        // check if indexes unique
-        Preconditions.checkArgument(indexes.size() == new HashSet<>(indexes).size(),
-                                    "field schemas should have unique indexes");
-
-        // check if indexes are sorted
-        final ArrayList<Integer> sortedList = new ArrayList<>(indexes);
-        Collections.sort(sortedList);
-        Preconditions.checkArgument(sortedList.equals(indexes), "field schemas should be sorted by index");
-
-        // check if there are no missing indexes, i.e., all the indexes are continuous. Since we already check for
-        // sorting, if the first index is 0 and the last is indexes.size - 1, then we have that ensurance.
+        // check if indexes are a continuous list with no duplicated elements, i.e., all indexes are unique, are sorted
+        // and there are no intermediary indexes missing.
         Preconditions.checkArgument(indexes.equals(IntStream.range(0, indexes.size()).boxed().collect(Collectors.toList())),
-                                    "field schemas have missing intermediary indexes");
+                                    "field schemas be sorted by increasing index, with no duplicated nor missing elements");
 
         Preconditions.checkArgument(
                 fieldSchemas.size() == fieldSchemas.stream().map(FieldSchema::getFieldName).collect(Collectors.toSet()).size(),

--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
@@ -23,9 +23,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;

--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/MLAlgorithmDescriptor.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/MLAlgorithmDescriptor.java
@@ -100,9 +100,10 @@ public class MLAlgorithmDescriptor {
     }
 
     /**
-     * Gets the URL pointing to the documentation about this algorithm.
+     * Gets the possible null URL pointing to the documentation about this algorithm.
      *
-     * @return The {@link URL} containing the documentation.
+     * @return The {@link URL} containing the documentation. Can be null if the received string representation was not
+     * a valid URL.
      */
     public URL getDocumentation() {
         return this.documentation;

--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/ChoiceFieldType.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/ChoiceFieldType.java
@@ -85,11 +85,9 @@ public class ChoiceFieldType implements ModelParameterType {
         if (this.allowedValues.contains(parameterValue)) {
             return Optional.empty();
         } else {
-            return Optional.of(
-                    new ParamValidationError(
-                            parameterName,
-                            parameterValue,
-                            "should be one of: " + this.allowedValues.stream().collect(Collectors.joining(", "))));
+            String reason = "should be one of: " + String.join(", ", this.allowedValues);
+
+            return Optional.of(new ParamValidationError(parameterName, parameterValue, reason));
         }
     }
 

--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/NumericFieldType.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/NumericFieldType.java
@@ -64,6 +64,7 @@ public class NumericFieldType implements ModelParameterType {
                              final ParameterConfigType parameterType,
                              final double defaultValue) {
 
+        Preconditions.checkArgument(minValue <= maxValue, "min value should be smaller or equal to max value");
         Preconditions.checkArgument(
                 defaultValue >= minValue && defaultValue <= maxValue,
                 "The default value must be within the min and max values."
@@ -71,7 +72,7 @@ public class NumericFieldType implements ModelParameterType {
 
         this.minValue = minValue;
         this.maxValue = maxValue;
-        this.parameterType = parameterType;
+        this.parameterType = Preconditions.checkNotNull(parameterType, "Parameter type can't be null");
         this.defaultValue = defaultValue;
     }
 
@@ -110,8 +111,6 @@ public class NumericFieldType implements ModelParameterType {
      * @return A new {@link NumericFieldType}.
      */
     public static NumericFieldType range(final double minValue, final double maxValue, final ParameterConfigType parameterType, final double defaultValue) {
-        Preconditions.checkArgument(minValue <= maxValue, "min value should be smaller than max value");
-
         return new NumericFieldType(minValue, maxValue, parameterType, defaultValue);
     }
 

--- a/openml-api/src/test/java/com/feedzai/openml/data/schema/CategoricalValueSchemaTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/data/schema/CategoricalValueSchemaTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -43,6 +44,16 @@ public class CategoricalValueSchemaTest {
      * Test nominal values to use.
      */
     private static final Set<String> NOMINAL_VALUES = ImmutableSet.of("val0", "val1");
+
+    /**
+     * Tests creating an instance with a nullable collection of values.
+     */
+    @Test
+    public void testNullValues() {
+        assertThatThrownBy(() -> new CategoricalValueSchema(true, null))
+                .as("The error thrown by an incorrect construction of a CategoricalValueSchema")
+                .isInstanceOf(NullPointerException.class);
+    }
 
     /**
      * Tests getting the nominal values.

--- a/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
@@ -175,7 +175,8 @@ public class DatasetSchemaTest {
 
         assertThatThrownBy(() -> new DatasetSchema(targetField.getFieldIndex(), allFields))
                 .as("The error thrown by an incorrect construction of a schema")
-                .isInstanceOf(IllegalArgumentException.class);    }
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 
     /**
      * Tests that the {@link FieldSchema} of the {@link DatasetSchema} don't have a missing intermediary index.

--- a/openml-api/src/test/java/com/feedzai/openml/provider/descriptor/ModelParameterTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/descriptor/ModelParameterTest.java
@@ -19,6 +19,10 @@ package com.feedzai.openml.provider.descriptor;
 
 import com.feedzai.openml.provider.descriptor.fieldtype.FreeTextFieldType;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,7 +32,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Nuno Diegues (nuno.diegues@feedzai.com)
  * @since 0.1.0
  */
+@RunWith(Parameterized.class)
 public class ModelParameterTest {
+
+    @Parameterized.Parameters
+    public static Object[] data() {
+        return new Object[] { true, false };
+    }
+
+    @Parameterized.Parameter
+    public boolean mandatory;
 
     /**
      * Tests for a valid parameter.
@@ -39,7 +52,7 @@ public class ModelParameterTest {
         final String paramName = "param1";
         final String descName = "desc1";
         final String help = "help1";
-        final boolean isMandatory = true;
+        final boolean isMandatory = this.mandatory;
         final FreeTextFieldType fieldType = new FreeTextFieldType("default");
 
         final ModelParameter modelParameter = new ModelParameter(paramName, descName, help, isMandatory, fieldType);
@@ -86,4 +99,6 @@ public class ModelParameterTest {
                 .isEqualTo(modelParameterClone.hashCode())
                 .isNotEqualTo(differentParam.hashCode());
     }
+
+
 }

--- a/openml-api/src/test/java/com/feedzai/openml/provider/descriptor/ModelParameterTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/descriptor/ModelParameterTest.java
@@ -22,8 +22,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.Collection;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -35,11 +33,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(Parameterized.class)
 public class ModelParameterTest {
 
+    /**
+     * Sets up the test parameter, representing whether the created {@link ModelParameter} should be mandatory.
+     *
+     * @return An array of {@link Object} representing the possible values for {@link #mandatory}.
+     */
     @Parameterized.Parameters
     public static Object[] data() {
         return new Object[] { true, false };
     }
 
+    /**
+     * If the {@link ModelParameter} created during the test should be mandatory or not.
+     */
     @Parameterized.Parameter
     public boolean mandatory;
 

--- a/openml-api/src/test/java/com/feedzai/openml/provider/descriptor/ModelParameterTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/descriptor/ModelParameterTest.java
@@ -34,6 +34,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ModelParameterTest {
 
     /**
+     * If the {@link ModelParameter} created during the test should be mandatory or not.
+     */
+    @Parameterized.Parameter
+    public boolean mandatory;
+
+    /**
      * Sets up the test parameter, representing whether the created {@link ModelParameter} should be mandatory.
      *
      * @return An array of {@link Object} representing the possible values for {@link #mandatory}.
@@ -42,12 +48,6 @@ public class ModelParameterTest {
     public static Object[] data() {
         return new Object[] { true, false };
     }
-
-    /**
-     * If the {@link ModelParameter} created during the test should be mandatory or not.
-     */
-    @Parameterized.Parameter
-    public boolean mandatory;
 
     /**
      * Tests for a valid parameter.

--- a/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/AbstractConfigFieldTypeTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/AbstractConfigFieldTypeTest.java
@@ -103,10 +103,11 @@ abstract class AbstractConfigFieldTypeTest<T extends ModelParameterType> {
         final Optional<ParamValidationError> result = fieldType.validate(paramName, paramValue);
 
         assertEquals(
-                String.format("Param %s with value %s should %s",
+                String.format("Param %s with value %s should %s, error: %s",
                               paramName,
                               paramValue,
-                              expectsError ? "not be valid" : "be valid"),
+                              expectsError ? "not be valid" : "be valid",
+                              result.map(ParamValidationError::getMessage).orElse("")),
                 result.isPresent(),
                 expectsError);
     }

--- a/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/ChoiceFieldTypeTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/ChoiceFieldTypeTest.java
@@ -45,6 +45,9 @@ public class ChoiceFieldTypeTest extends AbstractConfigFieldTypeTest<ChoiceField
         return new ChoiceFieldType(ImmutableSet.of("val1", "val2"), "val2");
     }
 
+    /**
+     * Tests the constructor verifications for invalid values.
+     */
     @Test
     public void validateConstructor() {
         assertThatThrownBy(() -> new ChoiceFieldType(null, "value2"))

--- a/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/ChoiceFieldTypeTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/ChoiceFieldTypeTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests the behaviour of the {@link ChoiceFieldType} class.
@@ -41,6 +43,29 @@ public class ChoiceFieldTypeTest extends AbstractConfigFieldTypeTest<ChoiceField
     @Override
     ChoiceFieldType getAnotherInstance() {
         return new ChoiceFieldType(ImmutableSet.of("val1", "val2"), "val2");
+    }
+
+    @Test
+    public void validateConstructor() {
+        assertThatThrownBy(() -> new ChoiceFieldType(null, "value2"))
+                .as("A ChoiceFieldType cannot have null 'allowedFields'")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new ChoiceFieldType(ImmutableSet.of("value1", "value2"), null))
+                .as("A ChoiceFieldType cannot have a null default value")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new ChoiceFieldType(ImmutableSet.of(), "value2"))
+                .as("A ChoiceFieldType cannot have an empty set of 'allowedFields'")
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> new ChoiceFieldType(ImmutableSet.of("value1", "value2"), "value3"))
+                .as("A ChoiceFieldType cannot have null a default value outside of allowed values")
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatCode(() -> new ChoiceFieldType(ImmutableSet.of("value1", "value2"), "value2"))
+                .as("A valid ChoiceFieldType constructor")
+                .doesNotThrowAnyException();
     }
 
     /**

--- a/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/NumericFieldTypeTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/NumericFieldTypeTest.java
@@ -113,7 +113,7 @@ public class NumericFieldTypeTest extends AbstractConfigFieldTypeTest<NumericFie
 
         assertThatCode(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, 0))
                 .as("A valid NumericFieldType constructor")
-                .doesNotThrowAnyException();
+                .MockDataset();
 
         assertThatCode(() -> NumericFieldType.range(-1, -1, NumericFieldType.ParameterConfigType.DOUBLE, -1))
                 .as("A  NumericFieldType with a max value equal to min")

--- a/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/NumericFieldTypeTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/NumericFieldTypeTest.java
@@ -100,6 +100,9 @@ public class NumericFieldTypeTest extends AbstractConfigFieldTypeTest<NumericFie
                 .isEqualTo(NumericFieldType.ParameterConfigType.DOUBLE);
     }
 
+    /**
+     * Tests the constructor verifications for invalid values.
+     */
     @Test
     public void validateConstructor() {
 
@@ -108,12 +111,12 @@ public class NumericFieldTypeTest extends AbstractConfigFieldTypeTest<NumericFie
                 .isInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> NumericFieldType.range(1, -1, NumericFieldType.ParameterConfigType.DOUBLE, 1))
-                .as("The min value cannpt be bigger than the max value")
+                .as("The min value cannot be bigger than the max value")
                 .isInstanceOf(IllegalArgumentException.class);
 
         assertThatCode(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, 0))
                 .as("A valid NumericFieldType constructor")
-                .MockDataset();
+                .doesNotThrowAnyException();
 
         assertThatCode(() -> NumericFieldType.range(-1, -1, NumericFieldType.ParameterConfigType.DOUBLE, -1))
                 .as("A  NumericFieldType with a max value equal to min")

--- a/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/NumericFieldTypeTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/NumericFieldTypeTest.java
@@ -21,6 +21,8 @@ import com.feedzai.openml.provider.descriptor.fieldtype.NumericFieldType;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests the behaviour of the {@link NumericFieldType} class.
@@ -62,13 +64,17 @@ public class NumericFieldTypeTest extends AbstractConfigFieldTypeTest<NumericFie
                 defaultValue
         );
 
-        assertValidationResult(fieldType, "param0", null, true);
-        assertValidationResult(fieldType, "param1", "", true);
-        assertValidationResult(fieldType, "param2", "non-parsable", true);
-        assertValidationResult(fieldType, "param3", String.valueOf(minValue - 1), true);
-        assertValidationResult(fieldType, "param4", String.valueOf(maxValue + 1), true);
-        assertValidationResult(fieldType, "param5", String.valueOf(minValue + 1), false);
+        assertValidationResult(fieldType, "param", null, true);
+        assertValidationResult(fieldType, "param", "", true);
+        assertValidationResult(fieldType, "param", "non-parsable", true);
 
+        assertValidationResult(fieldType, "param", String.valueOf(minValue - 1), true);
+        assertValidationResult(fieldType, "param", String.valueOf(minValue), false);
+        assertValidationResult(fieldType, "param", String.valueOf(minValue + 1), false);
+
+        assertValidationResult(fieldType, "param", String.valueOf(maxValue - 1), false);
+        assertValidationResult(fieldType, "param", String.valueOf(maxValue), false);
+        assertValidationResult(fieldType, "param", String.valueOf(maxValue + 1), true);
     }
 
     /**
@@ -92,6 +98,46 @@ public class NumericFieldTypeTest extends AbstractConfigFieldTypeTest<NumericFie
 
         assertThat(type1.getParameterType())
                 .isEqualTo(NumericFieldType.ParameterConfigType.DOUBLE);
+    }
+
+    @Test
+    public void validateConstructor() {
+
+        assertThatThrownBy(() ->  NumericFieldType.range(-1, 1, null, 0))
+                .as("A NumericFieldType cannot have a null parameter type")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> NumericFieldType.range(1, -1, NumericFieldType.ParameterConfigType.DOUBLE, 1))
+                .as("The min value cannpt be bigger than the max value")
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatCode(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, 0))
+                .as("A valid NumericFieldType constructor")
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> NumericFieldType.range(-1, -1, NumericFieldType.ParameterConfigType.DOUBLE, -1))
+                .as("A  NumericFieldType with a max value equal to min")
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, -1))
+                .as("A  NumericFieldType with a default value equal to min")
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, 0))
+                .as("A  NumericFieldType with a default value between min and max")
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, 1))
+                .as("A  NumericFieldType with a default value equal to max")
+                .doesNotThrowAnyException();
+
+        assertThatThrownBy(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, -2))
+                .as("A  NumericFieldType with a default value smaller than min")
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> NumericFieldType.range(-1, 1, NumericFieldType.ParameterConfigType.DOUBLE, 2))
+                .as("A  NumericFieldType with a default value bigger than max")
+                .isInstanceOf(IllegalArgumentException.class);
 
     }
 

--- a/openml-utils/src/main/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnum.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnum.java
@@ -60,7 +60,7 @@ public interface MLAlgorithmEnum {
                                                   final MachineLearningAlgorithmType algorithmType,
                                                   final String documentationLink) {
 
-        Preconditions.checkNotNull(documentationLink, "");
+        Preconditions.checkNotNull(documentationLink, "The documentation link should not be null");
 
         URL documentationUrl = null;
         try {

--- a/openml-utils/src/main/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnum.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnum.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.feedzai.openml.provider.descriptor.MLAlgorithmDescriptor;
 import com.feedzai.openml.provider.descriptor.MachineLearningAlgorithmType;
 import com.feedzai.openml.provider.descriptor.ModelParameter;
+import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,11 +59,15 @@ public interface MLAlgorithmEnum {
                                                   final Set<ModelParameter> algorithmParameters,
                                                   final MachineLearningAlgorithmType algorithmType,
                                                   final String documentationLink) {
+
+        Preconditions.checkNotNull(documentationLink, "");
+
         URL documentationUrl = null;
         try {
             documentationUrl = new URL(documentationLink);
         } catch (final MalformedURLException e) {
             logger.warn(String.format("The documentation URL for the algorithm descriptor '%s' is malformed", algorithmName), e);
+            throw new IllegalArgumentException(String.format("Supplied documentation link is not a valid URL: %s", e.getMessage()));
         }
 
         return new MLAlgorithmDescriptor(

--- a/openml-utils/src/main/java/com/feedzai/openml/util/data/encoding/EncodingHelper.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/data/encoding/EncodingHelper.java
@@ -107,7 +107,7 @@ public final class EncodingHelper implements Serializable {
             return value -> (Double) handleNullOrFailed(value, function, DEFAULT_CATEGORICAL_VALUE);
 
         } else {
-            final SerializableEncoder function = Object::toString;
+            final SerializableEncoder function = s -> s;
             return value -> (String) handleNullOrFailed(value, function, DEFAULT_STRING_VALUE);
         }
     }

--- a/openml-utils/src/main/java/com/feedzai/openml/util/validate/ValidationUtils.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/validate/ValidationUtils.java
@@ -187,18 +187,6 @@ public final class ValidationUtils {
             errorBuilder.add(new ParamValidationError("The map of parameters cannot be null"));
         }
 
-        if (Objects.isNull(schema.getFieldSchemas())) {
-            errorBuilder.add(new ParamValidationError("field schemas cannot be null"));
-        }
-
-        if (schema.getTargetIndex() < 0) {
-            errorBuilder.add(new ParamValidationError("target index cannot be negative"));
-        }
-
-        if (schema.getFieldSchemas().size() <= schema.getTargetIndex()) {
-            errorBuilder.add(new ParamValidationError("target index should not be bigger than the size of the fields"));
-        }
-
         return errorBuilder.build();
     }
 

--- a/openml-utils/src/test/java/com/feedzai/openml/mocks/MockInstanceTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/mocks/MockInstanceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.feedzai.openml.mocks;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+public class MockInstanceTest {
+
+    @Test
+    public void testDoubleArray() {
+
+        final double[] doubles = {0, 1, 2};
+
+        final MockInstance instance = new MockInstance(doubles);
+
+        final List<Double> values = Arrays.stream(doubles).boxed().collect(Collectors.toList());
+
+        values.forEach(idx -> {
+            assertThat(instance.getValue(idx.intValue()))
+                    .as("")
+                    .isEqualTo(idx);
+
+            assertThatThrownBy(() -> instance.getStringValue(idx.intValue()))
+                    .as("")
+                    .isInstanceOf(ClassCastException.class);
+        });
+
+    }
+
+    @Test
+    public void testList() {
+
+        final List<Serializable> values = ImmutableList.of("0", "1", "2");
+        final MockInstance instance = new MockInstance(values);
+
+        values.forEach(idx -> {
+            assertThat(instance.getStringValue(Integer.parseInt((String) idx)))
+                    .as("")
+                    .isEqualTo(idx);
+
+            assertThatThrownBy(() -> instance.getValue(Integer.parseInt((String) idx)))
+                    .as("")
+                    .isInstanceOf(ClassCastException.class);
+        });
+
+    }
+
+
+    @Test
+    public void testSize() {
+        final int numberFieldsSize = 10;
+        final MockInstance instance = new MockInstance(numberFieldsSize, new Random());
+
+        IntStream.range(0, numberFieldsSize).forEach(idx -> {
+            assertThatCode(() -> instance.getValue(idx))
+                    .as("")
+                    .doesNotThrowAnyException();
+        });
+
+        assertThatThrownBy(() -> instance.getValue(numberFieldsSize))
+                .as("")
+                .isInstanceOf(IndexOutOfBoundsException.class);
+
+    }
+
+}

--- a/openml-utils/src/test/java/com/feedzai/openml/mocks/MockInstanceTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/mocks/MockInstanceTest.java
@@ -31,9 +31,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-
+/**
+ * Class that tests the behaviour of an {@link MockInstance}.
+ *
+ * @since @@@feedzai.next.release@@@
+ * @author Pedro Rijo (pedro.rijo@feedzai.com)
+ */
 public class MockInstanceTest {
 
+    /**
+     * Tests the construction through {@link MockInstance#MockInstance(double[])}.
+     */
     @Test
     public void testDoubleArray() {
 
@@ -45,16 +53,19 @@ public class MockInstanceTest {
 
         values.forEach(idx -> {
             assertThat(instance.getValue(idx.intValue()))
-                    .as("")
+                    .as("The instance value")
                     .isEqualTo(idx);
 
             assertThatThrownBy(() -> instance.getStringValue(idx.intValue()))
-                    .as("")
+                    .as("The instance string value")
                     .isInstanceOf(ClassCastException.class);
         });
 
     }
 
+    /**
+     * Tests the construction through {@link MockInstance#MockInstance(List)}.
+     */
     @Test
     public void testList() {
 
@@ -63,30 +74,31 @@ public class MockInstanceTest {
 
         values.forEach(idx -> {
             assertThat(instance.getStringValue(Integer.parseInt((String) idx)))
-                    .as("")
+                    .as("The instance string value")
                     .isEqualTo(idx);
 
             assertThatThrownBy(() -> instance.getValue(Integer.parseInt((String) idx)))
-                    .as("")
+                    .as("The instance value")
                     .isInstanceOf(ClassCastException.class);
         });
 
     }
 
 
+    /**
+     * Tests the construction through {@link MockInstance#MockInstance(int, Random)}.
+     */
     @Test
     public void testSize() {
         final int numberFieldsSize = 10;
         final MockInstance instance = new MockInstance(numberFieldsSize, new Random());
 
-        IntStream.range(0, numberFieldsSize).forEach(idx -> {
-            assertThatCode(() -> instance.getValue(idx))
-                    .as("")
-                    .doesNotThrowAnyException();
-        });
+        IntStream.range(0, numberFieldsSize).forEach(idx -> assertThatCode(() -> instance.getValue(idx))
+                .as("The instance value for valid index")
+                .doesNotThrowAnyException());
 
         assertThatThrownBy(() -> instance.getValue(numberFieldsSize))
-                .as("")
+                .as("The instance value for an index bigger than asked")
                 .isInstanceOf(IndexOutOfBoundsException.class);
 
     }

--- a/openml-utils/src/test/java/com/feedzai/openml/util/ClassificationDatasetSchemaUtilTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/ClassificationDatasetSchemaUtilTest.java
@@ -17,15 +17,14 @@
 
 package com.feedzai.openml.util;
 
-import com.feedzai.openml.data.schema.CategoricalValueSchema;
-import com.feedzai.openml.data.schema.DatasetSchema;
-import com.feedzai.openml.data.schema.FieldSchema;
-import com.feedzai.openml.data.schema.NumericValueSchema;
+import com.feedzai.openml.data.schema.*;
 import com.feedzai.openml.util.data.ClassificationDatasetSchemaUtil;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -69,6 +68,27 @@ public class ClassificationDatasetSchemaUtilTest {
         assertThatThrownBy(() -> ClassificationDatasetSchemaUtil.getNumClassValues(datasetSchema))
                 .as("The error for not having a categorical target")
                 .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void testWithCategoricalSchema() {
+
+        final Integer returnValue = 10;
+
+        final Function<CategoricalValueSchema, Integer> fun = (categoricalValueSchema -> returnValue);
+
+        assertThat(ClassificationDatasetSchemaUtil.withCategoricalValueSchema(new NumericValueSchema(true), fun))
+                .as("")
+                .isEmpty();
+
+        assertThat(ClassificationDatasetSchemaUtil.withCategoricalValueSchema(new StringValueSchema(true), fun))
+                .as("")
+                .isEmpty();
+
+        assertThat(ClassificationDatasetSchemaUtil.withCategoricalValueSchema(new CategoricalValueSchema(true, ImmutableSet.of()), fun))
+                .as("")
+                .isNotEmpty()
+                .contains(returnValue);
     }
 
     /**

--- a/openml-utils/src/test/java/com/feedzai/openml/util/ClassificationDatasetSchemaUtilTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/ClassificationDatasetSchemaUtilTest.java
@@ -70,6 +70,9 @@ public class ClassificationDatasetSchemaUtilTest {
                 .isInstanceOf(RuntimeException.class);
     }
 
+    /**
+     * Tests the behaviour of {@link ClassificationDatasetSchemaUtil#withCategoricalValueSchema(AbstractValueSchema, Function)}.
+     */
     @Test
     public void testWithCategoricalSchema() {
 
@@ -78,15 +81,15 @@ public class ClassificationDatasetSchemaUtilTest {
         final Function<CategoricalValueSchema, Integer> fun = (categoricalValueSchema -> returnValue);
 
         assertThat(ClassificationDatasetSchemaUtil.withCategoricalValueSchema(new NumericValueSchema(true), fun))
-                .as("")
+                .as("The output of calling withCategoricalValueSchema on a NumericValueSchema")
                 .isEmpty();
 
         assertThat(ClassificationDatasetSchemaUtil.withCategoricalValueSchema(new StringValueSchema(true), fun))
-                .as("")
+                .as("The output of calling withCategoricalValueSchema on a StringValueSchema")
                 .isEmpty();
 
         assertThat(ClassificationDatasetSchemaUtil.withCategoricalValueSchema(new CategoricalValueSchema(true, ImmutableSet.of()), fun))
-                .as("")
+                .as("The output of calling withCategoricalValueSchema on a CategoricalValueSchema")
                 .isNotEmpty()
                 .contains(returnValue);
     }

--- a/openml-utils/src/test/java/com/feedzai/openml/util/algorithm/DummyAlgorithmEnum.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/algorithm/DummyAlgorithmEnum.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.feedzai.openml.util.algorithm;
+
+import com.feedzai.openml.provider.descriptor.MLAlgorithmDescriptor;
+import com.feedzai.openml.provider.descriptor.MachineLearningAlgorithmType;
+import com.google.common.collect.ImmutableSet;
+
+public enum DummyAlgorithmEnum implements MLAlgorithmEnum {
+
+    /**
+     * Default Classification algorithm used for all Scikit-learn models.
+     */
+    DUMMY(MLAlgorithmEnum.createDescriptor(
+            "Classification Algorithm",
+            ImmutableSet.of(),
+            MachineLearningAlgorithmType.MULTI_CLASSIFICATION,
+            "https://feedzai.com/"
+    ));
+
+    /**
+     * {@link MLAlgorithmDescriptor} for this algorithm.
+     */
+    public final MLAlgorithmDescriptor descriptor;
+
+    /**
+     * Constructor.
+     *
+     * @param descriptor {@link MLAlgorithmDescriptor} for this algorithm.
+     */
+    DummyAlgorithmEnum(final MLAlgorithmDescriptor descriptor) {
+        this.descriptor = descriptor;
+    }
+
+    @Override
+    public MLAlgorithmDescriptor getAlgorithmDescriptor() {
+        return this.descriptor;
+    }
+}

--- a/openml-utils/src/test/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnumTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnumTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.feedzai.openml.util.algorithm;
+
+import com.feedzai.openml.provider.descriptor.MLAlgorithmDescriptor;
+import com.feedzai.openml.provider.descriptor.MachineLearningAlgorithmType;
+import com.feedzai.openml.provider.descriptor.ModelParameter;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class MLAlgorithmEnumTest {
+
+    @Test
+    public void testCreateDescriptor() {
+        final String algoName = "algoName";
+        final ImmutableSet<ModelParameter> parameters = ImmutableSet.of();
+        final MachineLearningAlgorithmType algorithmType = MachineLearningAlgorithmType.BINARY_CLASSIFICATION;
+        final String documentationLink = "https://feedzai.com/";
+
+        MLAlgorithmDescriptor descriptor = MLAlgorithmEnum.createDescriptor(algoName, parameters, algorithmType, documentationLink);
+
+        assertThat(descriptor.getAlgorithmName())
+                .as("")
+                .isEqualTo(algoName);
+
+        assertThat(descriptor.getParameters())
+                .as("")
+                .isEqualTo(parameters);
+
+        assertThat(descriptor.getAlgorithmType())
+                .as("")
+                .isEqualTo(algorithmType);
+
+        assertThat(descriptor.getDocumentation().toString())
+                .as("")
+                .isEqualTo(documentationLink);
+
+    }
+
+    @Test
+    public void testInvalidCreateDescriptor() {
+        final String algoName = "algoName";
+        final ImmutableSet<ModelParameter> parameters = ImmutableSet.of();
+        final MachineLearningAlgorithmType algorithmType = MachineLearningAlgorithmType.BINARY_CLASSIFICATION;
+        final String documentationLink = "https://feedzai.com/";
+
+        assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(null, parameters, algorithmType, documentationLink))
+                .as("")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, null, algorithmType, documentationLink))
+                .as("")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, parameters, null, documentationLink))
+                .as("")
+                .isInstanceOf(NullPointerException.class);
+
+
+        assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, parameters, algorithmType, null))
+                .as("")
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void testInvalidUrl() {
+        final String algoName = "algoName";
+        final ImmutableSet<ModelParameter> parameters = ImmutableSet.of();
+        final MachineLearningAlgorithmType algorithmType = MachineLearningAlgorithmType.BINARY_CLASSIFICATION;
+
+        assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, parameters, algorithmType, "random string"))
+                .as("")
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testGetName() {
+        assertThat(DummyAlgorithmEnum.DUMMY.getName())
+                .as("")
+                .isEqualTo(DummyAlgorithmEnum.DUMMY.getAlgorithmDescriptor().getAlgorithmName());
+    }
+
+    @Test
+    public void testGetDescriptors() {
+        Set<MLAlgorithmDescriptor> descriptors = MLAlgorithmEnum.getDescriptors(DummyAlgorithmEnum.values());
+
+        assertThat(descriptors)
+                .as("")
+                .hasSize(DummyAlgorithmEnum.values().length);
+
+        assertThat(descriptors)
+                .as("")
+                .isEqualTo(Stream.of(DummyAlgorithmEnum.values()).map(DummyAlgorithmEnum::getAlgorithmDescriptor).collect(Collectors.toSet()));
+    }
+
+    @Test
+    public void testGetByName() {
+        assertThat(MLAlgorithmEnum.getByName(DummyAlgorithmEnum.values(), null))
+        .as("")
+        .isEmpty();
+
+        assertThat(MLAlgorithmEnum.getByName(DummyAlgorithmEnum.values(), "random name"))
+                .as("")
+                .isEmpty();
+
+        assertThat(MLAlgorithmEnum.getByName(DummyAlgorithmEnum.values(), DummyAlgorithmEnum.DUMMY.getName()))
+                .as("")
+                .isPresent()
+                .contains(DummyAlgorithmEnum.DUMMY);
+
+    }
+
+}

--- a/openml-utils/src/test/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnumTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/algorithm/MLAlgorithmEnumTest.java
@@ -30,8 +30,18 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+/**
+ * Class to test the behaviour of {@link MLAlgorithmEnum}.
+ *
+ * @since @@@feedzai.next.release@@@
+ * @author Pedro Rijo (pedro.rijo@feedzai.com)
+ */
 public class MLAlgorithmEnumTest {
 
+    /**
+     * Tests the {@link MLAlgorithmEnum#createDescriptor(String, Set, MachineLearningAlgorithmType, String)} with
+     * a valid input.
+     */
     @Test
     public void testCreateDescriptor() {
         final String algoName = "algoName";
@@ -39,26 +49,30 @@ public class MLAlgorithmEnumTest {
         final MachineLearningAlgorithmType algorithmType = MachineLearningAlgorithmType.BINARY_CLASSIFICATION;
         final String documentationLink = "https://feedzai.com/";
 
-        MLAlgorithmDescriptor descriptor = MLAlgorithmEnum.createDescriptor(algoName, parameters, algorithmType, documentationLink);
+        final MLAlgorithmDescriptor descriptor = MLAlgorithmEnum.createDescriptor(algoName, parameters, algorithmType, documentationLink);
 
         assertThat(descriptor.getAlgorithmName())
-                .as("")
+                .as("The descriptor algorithm name")
                 .isEqualTo(algoName);
 
         assertThat(descriptor.getParameters())
-                .as("")
+                .as("The descriptor parameters")
                 .isEqualTo(parameters);
 
         assertThat(descriptor.getAlgorithmType())
-                .as("")
+                .as("The descriptor algorithm type")
                 .isEqualTo(algorithmType);
 
         assertThat(descriptor.getDocumentation().toString())
-                .as("")
+                .as("The descriptor documentation URL")
                 .isEqualTo(documentationLink);
 
     }
 
+    /**
+     * Tests the {@link MLAlgorithmEnum#createDescriptor(String, Set, MachineLearningAlgorithmType, String)} with
+     * an invalid input.
+     */
     @Test
     public void testInvalidCreateDescriptor() {
         final String algoName = "algoName";
@@ -67,23 +81,26 @@ public class MLAlgorithmEnumTest {
         final String documentationLink = "https://feedzai.com/";
 
         assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(null, parameters, algorithmType, documentationLink))
-                .as("")
+                .as("The exception throw by trying to create a descriptor with null algorithm name")
                 .isInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, null, algorithmType, documentationLink))
-                .as("")
+                .as("The exception throw by trying to create a descriptor with null algorithm params")
                 .isInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, parameters, null, documentationLink))
-                .as("")
+                .as("The exception throw by trying to create a descriptor with null algorithm type")
                 .isInstanceOf(NullPointerException.class);
 
-
         assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, parameters, algorithmType, null))
-                .as("")
+                .as("The exception throw by trying to create a descriptor with null URL")
                 .isInstanceOf(NullPointerException.class);
     }
 
+    /**
+     * Tests the {@link MLAlgorithmEnum#createDescriptor(String, Set, MachineLearningAlgorithmType, String)} with
+     * an invalid URL.
+     */
     @Test
     public void testInvalidUrl() {
         final String algoName = "algoName";
@@ -91,42 +108,51 @@ public class MLAlgorithmEnumTest {
         final MachineLearningAlgorithmType algorithmType = MachineLearningAlgorithmType.BINARY_CLASSIFICATION;
 
         assertThatThrownBy(() -> MLAlgorithmEnum.createDescriptor(algoName, parameters, algorithmType, "random string"))
-                .as("")
+                .as("The exception throw by trying to create a descriptor with an invalid URL")
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    /**
+     * Tests the {@link MLAlgorithmEnum#getName}.
+     */
     @Test
     public void testGetName() {
         assertThat(DummyAlgorithmEnum.DUMMY.getName())
-                .as("")
+                .as("The dummy algorithm name")
                 .isEqualTo(DummyAlgorithmEnum.DUMMY.getAlgorithmDescriptor().getAlgorithmName());
     }
 
+    /**
+     * Tests the {@link MLAlgorithmEnum#getDescriptors(MLAlgorithmEnum[])}.
+     */
     @Test
     public void testGetDescriptors() {
-        Set<MLAlgorithmDescriptor> descriptors = MLAlgorithmEnum.getDescriptors(DummyAlgorithmEnum.values());
+        final Set<MLAlgorithmDescriptor> descriptors = MLAlgorithmEnum.getDescriptors(DummyAlgorithmEnum.values());
 
         assertThat(descriptors)
-                .as("")
+                .as("The number of descriptors")
                 .hasSize(DummyAlgorithmEnum.values().length);
 
         assertThat(descriptors)
-                .as("")
+                .as("The descriptors returned by the auxiliary method")
                 .isEqualTo(Stream.of(DummyAlgorithmEnum.values()).map(DummyAlgorithmEnum::getAlgorithmDescriptor).collect(Collectors.toSet()));
     }
 
+    /**
+     * Tests the {@link MLAlgorithmEnum#getByName(MLAlgorithmEnum[], String)}.
+     */
     @Test
     public void testGetByName() {
         assertThat(MLAlgorithmEnum.getByName(DummyAlgorithmEnum.values(), null))
-        .as("")
-        .isEmpty();
+                .as("The get by name for null argument")
+                .isEmpty();
 
         assertThat(MLAlgorithmEnum.getByName(DummyAlgorithmEnum.values(), "random name"))
-                .as("")
+                .as("The get by name for an unexisting name")
                 .isEmpty();
 
         assertThat(MLAlgorithmEnum.getByName(DummyAlgorithmEnum.values(), DummyAlgorithmEnum.DUMMY.getName()))
-                .as("")
+                .as("The get by name for an existing name")
                 .isPresent()
                 .contains(DummyAlgorithmEnum.DUMMY);
 

--- a/openml-utils/src/test/java/com/feedzai/openml/util/data/encoding/EncodingHelperTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/data/encoding/EncodingHelperTest.java
@@ -238,7 +238,7 @@ public class EncodingHelperTest {
      * Tests the existing encoders from {@link EncodingHelper#encoderForField(AbstractValueSchema)}.
      */
     @Test
-    public void testEncoders() {
+    public void testEncodersOnNulls() {
         final NumericValueSchema numericValueSchema = new NumericValueSchema(true);
         final EncodingHelper.SerializableEncoder numericEncoder = EncodingHelper.encoderForField(numericValueSchema);
         assertThat(numericEncoder.apply(null))

--- a/openml-utils/src/test/java/com/feedzai/openml/util/data/encoding/EncodingHelperTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/data/encoding/EncodingHelperTest.java
@@ -42,6 +42,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 public class EncodingHelperTest {
 
+    @Test
+    public void testNull() {
+        assertThatThrownBy(() -> new EncodingHelper(null))
+                .as("The error thrown by an incorrect construction of a CategoricalValueSchema")
+                .isInstanceOf(NullPointerException.class);
+    }
+
     /**
      * Tests the encoding of different types of schema fields.
      */
@@ -220,6 +227,27 @@ public class EncodingHelperTest {
 
         assertThat(encodingHelper.encode("ERROR", fieldIndex))
                 .as("Encoding a string")
+                .isEqualTo(Double.NaN);
+    }
+
+    @Test
+    public void testEncoders() {
+        final NumericValueSchema numericValueSchema = new NumericValueSchema(true);
+        final EncodingHelper.SerializableEncoder numericEncoder = EncodingHelper.encoderForField(numericValueSchema);
+        assertThat(numericEncoder.apply(null))
+                .as("")
+                .isEqualTo(Double.NaN);
+
+        final StringValueSchema stringValueSchema = new StringValueSchema(true);
+        final EncodingHelper.SerializableEncoder stringEncoder = EncodingHelper.encoderForField(stringValueSchema);
+        assertThat(stringEncoder.apply(null))
+                .as("")
+                .isEqualTo(null);
+
+        final CategoricalValueSchema categoricalSchema = new CategoricalValueSchema(true, ImmutableSet.of());
+        final EncodingHelper.SerializableEncoder categoricalEncoder = EncodingHelper.encoderForField(categoricalSchema);
+        assertThat(categoricalEncoder.apply(null))
+                .as("")
                 .isEqualTo(Double.NaN);
     }
 }

--- a/openml-utils/src/test/java/com/feedzai/openml/util/data/encoding/EncodingHelperTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/data/encoding/EncodingHelperTest.java
@@ -17,6 +17,7 @@
 
 package com.feedzai.openml.util.data.encoding;
 
+import com.feedzai.openml.data.schema.AbstractValueSchema;
 import com.feedzai.openml.data.schema.CategoricalValueSchema;
 import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.data.schema.FieldSchema;
@@ -42,6 +43,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 public class EncodingHelperTest {
 
+    /**
+     * Tests the behaviour of the {@link EncodingHelper} constructor with null arguments.
+     */
     @Test
     public void testNull() {
         assertThatThrownBy(() -> new EncodingHelper(null))
@@ -230,24 +234,27 @@ public class EncodingHelperTest {
                 .isEqualTo(Double.NaN);
     }
 
+    /**
+     * Tests the existing encoders from {@link EncodingHelper#encoderForField(AbstractValueSchema)}.
+     */
     @Test
     public void testEncoders() {
         final NumericValueSchema numericValueSchema = new NumericValueSchema(true);
         final EncodingHelper.SerializableEncoder numericEncoder = EncodingHelper.encoderForField(numericValueSchema);
         assertThat(numericEncoder.apply(null))
-                .as("")
+                .as("The result of applying the numeric encoder to a null")
                 .isEqualTo(Double.NaN);
 
         final StringValueSchema stringValueSchema = new StringValueSchema(true);
         final EncodingHelper.SerializableEncoder stringEncoder = EncodingHelper.encoderForField(stringValueSchema);
         assertThat(stringEncoder.apply(null))
-                .as("")
+                .as("The result of applying the string encoder to a null")
                 .isEqualTo(null);
 
         final CategoricalValueSchema categoricalSchema = new CategoricalValueSchema(true, ImmutableSet.of());
         final EncodingHelper.SerializableEncoder categoricalEncoder = EncodingHelper.encoderForField(categoricalSchema);
         assertThat(categoricalEncoder.apply(null))
-                .as("")
+                .as("The result of applying the categorical encoder to a null")
                 .isEqualTo(Double.NaN);
     }
 }

--- a/openml-utils/src/test/java/com/feedzai/openml/util/load/LoadSchemaUtilsTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/load/LoadSchemaUtilsTest.java
@@ -17,8 +17,12 @@
 
 package com.feedzai.openml.util.load;
 
+import com.feedzai.openml.data.schema.CategoricalValueSchema;
 import com.feedzai.openml.data.schema.DatasetSchema;
+import com.feedzai.openml.data.schema.NumericValueSchema;
+import com.feedzai.openml.data.schema.StringValueSchema;
 import com.feedzai.openml.provider.exception.ModelLoadingException;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import java.io.File;
@@ -54,10 +58,36 @@ public class LoadSchemaUtilsTest {
      * Tests that when there is an error with the json file it will return an empty optional.
      */
     @Test
-    public void notExistTest() {
+    public void dirNotExistTest() {
         assertThatThrownBy(() -> LoadSchemaUtils.datasetSchemaFromJson(Paths.get("dummy")))
                 .as("the dataset schema doesn't exist")
                 .hasMessageContaining("The path")
                 .hasMessageContaining("should be a directory");
+    }
+
+    @Test
+    public void jsonNotExistTest() {
+        final String directoryPath = getClass().getResource(File.separator + "wrong_model_000").getPath();
+
+        assertThatThrownBy(() -> LoadSchemaUtils.datasetSchemaFromJson(Paths.get(directoryPath)))
+                .as("")
+                .isInstanceOf(ModelLoadingException.class)
+                .hasMessageContaining("model.json ");
+    }
+
+    @Test
+    public void valueSchemaToString() {
+
+        assertThat(LoadSchemaUtils.getValueSchemaTypeToString(new StringValueSchema(true)))
+                .as("")
+                .isEqualTo(LoadSchemaUtils.STRING);
+
+        assertThat(LoadSchemaUtils.getValueSchemaTypeToString(new CategoricalValueSchema(true, ImmutableSet.of())))
+                .as("")
+                .isEqualTo(LoadSchemaUtils.CATEGORICAL);
+
+        assertThat(LoadSchemaUtils.getValueSchemaTypeToString(new NumericValueSchema(true)))
+                .as("")
+                .isEqualTo(LoadSchemaUtils.NUMERIC);
     }
 }

--- a/openml-utils/src/test/java/com/feedzai/openml/util/load/LoadSchemaUtilsTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/load/LoadSchemaUtilsTest.java
@@ -17,6 +17,7 @@
 
 package com.feedzai.openml.util.load;
 
+import com.feedzai.openml.data.schema.AbstractValueSchema;
 import com.feedzai.openml.data.schema.CategoricalValueSchema;
 import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.data.schema.NumericValueSchema;
@@ -26,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -65,29 +67,36 @@ public class LoadSchemaUtilsTest {
                 .hasMessageContaining("should be a directory");
     }
 
+    /**
+     * Tests the behaviour of {@link LoadSchemaUtils#datasetSchemaFromJson(Path)} when the folder doesn't contain
+     * the model.json file.
+     */
     @Test
     public void jsonNotExistTest() {
         final String directoryPath = getClass().getResource(File.separator + "wrong_model_000").getPath();
 
         assertThatThrownBy(() -> LoadSchemaUtils.datasetSchemaFromJson(Paths.get(directoryPath)))
-                .as("")
+                .as("The exception thrown by loading the schema from a path without the model.json file")
                 .isInstanceOf(ModelLoadingException.class)
                 .hasMessageContaining("model.json ");
     }
 
+    /**
+     * Tests {@link LoadSchemaUtils#getValueSchemaTypeToString(AbstractValueSchema)}.
+     */
     @Test
     public void valueSchemaToString() {
 
         assertThat(LoadSchemaUtils.getValueSchemaTypeToString(new StringValueSchema(true)))
-                .as("")
+                .as("The string representation of a StringValueSchema")
                 .isEqualTo(LoadSchemaUtils.STRING);
 
         assertThat(LoadSchemaUtils.getValueSchemaTypeToString(new CategoricalValueSchema(true, ImmutableSet.of())))
-                .as("")
+                .as("The string representation of a CategoricalValueSchema")
                 .isEqualTo(LoadSchemaUtils.CATEGORICAL);
 
         assertThat(LoadSchemaUtils.getValueSchemaTypeToString(new NumericValueSchema(true)))
-                .as("")
+                .as("The string representation of a NumericValueSchema")
                 .isEqualTo(LoadSchemaUtils.NUMERIC);
     }
 }

--- a/openml-utils/src/test/java/com/feedzai/openml/util/validate/ValidationUtilsTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/validate/ValidationUtilsTest.java
@@ -52,6 +52,31 @@ public class ValidationUtilsTest {
                 .isEmpty();
     }
 
+    @Test
+    public void testBaseValidationErrors() {
+
+        final DatasetSchema schema = TestDatasetSchemaBuilder.builder()
+                .withCategoricalFields(3)
+                .withNumericalFields(3)
+                .withStringFields(3)
+                .build();
+
+        assertThat(ValidationUtils.baseLoadValidations(null, ImmutableMap.of("param1", "val1")))
+                .as("")
+                .isNotEmpty()
+                .hasSize(1);
+
+        assertThat(ValidationUtils.baseLoadValidations(schema, null))
+                .as("")
+                .isNotEmpty()
+                .hasSize(1);
+
+        assertThat(ValidationUtils.baseLoadValidations(null, null))
+                .as("")
+                .isNotEmpty()
+                .hasSize(2);
+    }
+
     /**
      * Tests that the {@link ValidationUtils#checkNoFieldsOfType(DatasetSchema, Class)} does not return errors when
      * searching for categorical fields in a schema without categoricals.

--- a/openml-utils/src/test/java/com/feedzai/openml/util/validate/ValidationUtilsTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/validate/ValidationUtilsTest.java
@@ -52,6 +52,9 @@ public class ValidationUtilsTest {
                 .isEmpty();
     }
 
+    /**
+     * Tests that {@link ValidationUtils#baseLoadValidations(DatasetSchema, Map)} can return some errors.
+     */
     @Test
     public void testBaseValidationErrors() {
 
@@ -62,17 +65,17 @@ public class ValidationUtilsTest {
                 .build();
 
         assertThat(ValidationUtils.baseLoadValidations(null, ImmutableMap.of("param1", "val1")))
-                .as("")
+                .as("The list of errors found with a null schema")
                 .isNotEmpty()
                 .hasSize(1);
 
         assertThat(ValidationUtils.baseLoadValidations(schema, null))
-                .as("")
+                .as("The list of errors found with null parameters")
                 .isNotEmpty()
                 .hasSize(1);
 
         assertThat(ValidationUtils.baseLoadValidations(null, null))
-                .as("")
+                .as("The list of errors found with all arguments as null")
                 .isNotEmpty()
                 .hasSize(2);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
                         <param>hashCode</param>
                         <param>equals</param>
                     </excludedMethods>
-                    <mutationThreshold>70</mutationThreshold>
+                    <mutationThreshold>78</mutationThreshold>
                     <threads>2</threads>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
-        <pitest.version>1.4.0</pitest.version>
+        <pitest.version>1.4.1</pitest.version>
     </properties>
 
     <dependencyManagement>
@@ -268,7 +268,10 @@
                         <param>hashCode</param>
                         <param>equals</param>
                     </excludedMethods>
-                    <mutationThreshold>55</mutationThreshold>
+                    <excludedClasses>
+                        <param>com.feedzai.openml.util.algorithm.GenericAlgorithm</param>
+                    </excludedClasses>
+                    <mutationThreshold>70</mutationThreshold>
                     <threads>2</threads>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -265,9 +265,6 @@
                         <param>hashCode</param>
                         <param>equals</param>
                     </excludedMethods>
-                    <excludedClasses>
-                        <param>com.feedzai.openml.util.algorithm.GenericAlgorithm</param>
-                    </excludedClasses>
                     <mutationThreshold>70</mutationThreshold>
                     <threads>2</threads>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
         <slf4j.version>1.7.25</slf4j.version>
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
-        <pitest.version>1.4.1</pitest.version>
     </properties>
 
     <dependencyManagement>
@@ -145,11 +144,6 @@
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.pitest</groupId>
-                <artifactId>pitest-maven</artifactId>
-                <version>${pitest.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -254,10 +248,13 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.pitest</groupId>
-                <artifactId>pitest-maven</artifactId>
-                <version>${pitest.version}</version>
+                <groupId>eu.stamp-project</groupId>
+                <artifactId>pitmp-maven-plugin</artifactId>
+                <version>1.3.4</version>
                 <configuration>
+                    <skippedModules>
+                        <param>openml-example</param>
+                    </skippedModules>
                     <mutateStaticInitializers>true</mutateStaticInitializers>
                     <mutators>
                         <mutator>ALL</mutator>
@@ -273,16 +270,6 @@
                     </excludedClasses>
                     <mutationThreshold>70</mutationThreshold>
                     <threads>2</threads>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>eu.stamp-project</groupId>
-                <artifactId>pitmp-maven-plugin</artifactId>
-                <version>1.3.4</version>
-                <configuration>
-                    <skippedModules>
-                        <param>openml-example</param>
-                    </skippedModules>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,11 @@
                 <groupId>eu.stamp-project</groupId>
                 <artifactId>pitmp-maven-plugin</artifactId>
                 <version>1.3.4</version>
+                <configuration>
+                    <skippedModules>
+                        <param>openml-example</param>
+                    </skippedModules>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Continuation from #33, separating in a different PR to be easier to see introduced changes.

Fix openml-api from mutation testing report. Mutation Testing score is still not 100% because some details we are not asserting, for instance `ParamValidationError` error message contents.

I've also found that the framework gives some false positives in lines containing `return true;` (or false), since it replaces the return type with `true` and no tests fail (obviously, no real change has been introduced). Will check if it's possible to ignore those false positives, or if it's possible to improve the framework.

Will add openml-utils improvements ASAP

**Edit:** 

- The issue on false positives was quickly fixed on https://github.com/hcoles/pitest/issues/497 
- openml-api and openml-utils with several fixes suggested by PIT
- several mutations survived because we don't assert string messages directly. Will look into it to check how to disable such mutation