### PR TITLE
Make DatasetSchema target variables optional

### DIFF
--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -54,14 +55,26 @@ public class DatasetSchema implements Serializable {
     /**
      * Creates a new instance.
      *
-     * @param targetIndex  The index of the target field.
+     * @param targetIndex  The index of the target field. Use a negative value (or {@link #DatasetSchema(List)}) to represent no
+     *                     target variable.
      * @param fieldSchemas The list of {@link FieldSchema} that represent each feature.
      */
     public DatasetSchema(final int targetIndex,
                          final List<FieldSchema> fieldSchemas) {
 
         this.fieldSchemas = checkFieldSchemas(fieldSchemas);
-        this.targetIndex = Preconditions.checkElementIndex(targetIndex, fieldSchemas.size(), "target index should be a valid index");
+        this.targetIndex = targetIndex >= 0
+                ? Preconditions.checkElementIndex(targetIndex, fieldSchemas.size(), "target index should be a valid index")
+                : targetIndex;
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param fieldSchemas The list of {@link FieldSchema} that represent each feature.
+     */
+    public DatasetSchema(final List<FieldSchema> fieldSchemas) {
+        this(-1, fieldSchemas);
     }
 
     /**
@@ -92,10 +105,10 @@ public class DatasetSchema implements Serializable {
     /**
      * Gets the index of the target field (the field to predict).
      *
-     * @return The target field index.
+     * @return The target field index wrapped in an {@link Optional} object, or {@link Optional#empty()} if no target variable is specified.
      */
-    public int getTargetIndex() {
-        return this.targetIndex;
+    public Optional<Integer> getTargetIndex() {
+        return this.targetIndex < 0 ? Optional.empty() : Optional.of(this.targetIndex);
     }
 
     /**

--- a/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,6 +49,17 @@ public class DatasetSchemaTest {
         assertThatThrownBy(() -> new DatasetSchema(2, ImmutableList.of(FIELD_SCHEMA)))
                 .as("The error thrown by an incorrect construction of a schema")
                 .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    /**
+     * Tests that by creating a {@link DatasetSchema} with no information on the target variable will make {@link DatasetSchema#getTargetIndex()}
+     * return {@link Optional#empty()}.
+     */
+    @Test
+    public final void testNoTargetIndex() {
+        assertThat(new DatasetSchema(ImmutableList.of(FIELD_SCHEMA)).getTargetIndex())
+                .as("A dataset with no target variable")
+                .isNotPresent();
     }
 
     /**
@@ -82,7 +94,7 @@ public class DatasetSchemaTest {
         final DatasetSchema datasetSchema = new DatasetSchema(3, allFields);
 
         assertThat(datasetSchema.getTargetIndex())
-                .isEqualTo(3);
+                .hasValue(3);
 
         assertThat(datasetSchema.getFieldSchemas())
                 .isEqualTo(allFields);

--- a/openml-example/src/main/java/com/feedzai/openml/example/ExampleModelLoader.java
+++ b/openml-example/src/main/java/com/feedzai/openml/example/ExampleModelLoader.java
@@ -52,11 +52,19 @@ public class ExampleModelLoader implements MachineLearningModelLoader<ExampleMod
         this.indexToPredict = indexToPredict;
     }
 
+    /**
+     * {@inheritDoc}.
+     * @param schema The schema for this implementation requires a predefined target variable.
+     */
     @Override
     public ExampleModel loadModel(final Path modelPath, final DatasetSchema schema) {
+        if (!schema.getTargetIndex().isPresent()) {
+            throw new IllegalArgumentException("This model requires a schema with a predefined target variable.");
+        }
+
         final int numberClasses = ((CategoricalValueSchema) schema
                 .getFieldSchemas()
-                .get(schema.getTargetIndex())
+                .get(schema.getTargetIndex().get())
                 .getValueSchema())
                 .getNominalValues()
                 .size();

--- a/openml-example/src/test/java/com/feedzai/openml/example/ExampleModelLoaderTest.java
+++ b/openml-example/src/test/java/com/feedzai/openml/example/ExampleModelLoaderTest.java
@@ -52,9 +52,7 @@ public class ExampleModelLoaderTest {
     }
 
     /**
-     * Tests that [[TODO]]
-     *
-     * @since @@@feedzai.next.release@@@
+     * Tests that {@link ExampleModelLoader} cannot load model with a schema that has no target variable.
      */
     @Test
     public final void testLoadModelWithNoSchema() {

--- a/openml-example/src/test/java/com/feedzai/openml/example/ExampleModelLoaderTest.java
+++ b/openml-example/src/test/java/com/feedzai/openml/example/ExampleModelLoaderTest.java
@@ -20,6 +20,7 @@ package com.feedzai.openml.example;
 import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.provider.exception.ModelLoadingException;
 import com.feedzai.openml.util.data.schema.TestDatasetSchemaBuilder;
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import java.nio.file.Path;
@@ -48,6 +49,22 @@ public class ExampleModelLoaderTest {
         assertThat(loader.loadModel(modelPath, testSchema))
                 .as("The result loading a model with the Example Loader")
                 .isNotNull();
+    }
+
+    /**
+     * Tests that [[TODO]]
+     *
+     * @since @@@feedzai.next.release@@@
+     */
+    @Test
+    public final void testLoadModelWithNoSchema() {
+        final ExampleModelLoader loader = new ExampleModelLoader(0);
+        final Path modelPath = get("dummy");
+        final DatasetSchema testSchema = new DatasetSchema(ImmutableList.of());
+        assertThatThrownBy(() -> loader.loadModel(modelPath, testSchema))
+                .as("The of loading a model with a dataset which has no target variable.")
+                .isInstanceOf(IllegalArgumentException.class);
+
     }
 
     /**

--- a/openml-utils/src/main/java/com/feedzai/openml/util/data/ClassificationDatasetSchemaUtil.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/data/ClassificationDatasetSchemaUtil.java
@@ -20,6 +20,7 @@ package com.feedzai.openml.util.data;
 import com.feedzai.openml.data.schema.AbstractValueSchema;
 import com.feedzai.openml.data.schema.CategoricalValueSchema;
 import com.feedzai.openml.data.schema.DatasetSchema;
+import com.feedzai.openml.data.schema.FieldSchema;
 import com.feedzai.openml.model.ClassificationMLModel;
 
 import java.util.Optional;
@@ -43,16 +44,13 @@ public final class ClassificationDatasetSchemaUtil {
      * problem.
      *
      * @param datasetSchema The {@link DatasetSchema}.
-     * @return The number of classes on the target variable.
+     * @return The number of classes on the target variable, if a target variable is defined, or {@link Optional#empty()} otheriwse.
      */
-    public static int getNumClassValues(final DatasetSchema datasetSchema) {
-
-        final AbstractValueSchema valueSchema = datasetSchema
-                .getFieldSchemas()
-                .get(datasetSchema.getTargetIndex())
-                .getValueSchema();
-
-        return getNumClassValues(valueSchema);
+    public static Optional<Integer> getNumClassValues(final DatasetSchema datasetSchema) {
+        return datasetSchema.getTargetIndex()
+                .map(datasetSchema.getFieldSchemas()::get)
+                .map(FieldSchema::getValueSchema)
+                .map(ClassificationDatasetSchemaUtil::getNumClassValues);
     }
 
     /**

--- a/openml-utils/src/main/java/com/feedzai/openml/util/data/ClassificationDatasetSchemaUtil.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/data/ClassificationDatasetSchemaUtil.java
@@ -44,7 +44,7 @@ public final class ClassificationDatasetSchemaUtil {
      * problem.
      *
      * @param datasetSchema The {@link DatasetSchema}.
-     * @return The number of classes on the target variable, if a target variable is defined, or {@link Optional#empty()} otheriwse.
+     * @return The number of classes on the target variable, if a target variable is defined, or {@link Optional#empty()} otherwise.
      */
     public static Optional<Integer> getNumClassValues(final DatasetSchema datasetSchema) {
         return datasetSchema.getTargetIndex()

--- a/openml-utils/src/main/java/com/feedzai/openml/util/data/InstanceUtils.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/data/InstanceUtils.java
@@ -22,8 +22,6 @@ import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.data.schema.StringValueSchema;
 
 import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
 
 /**
  * Utility class to help computing instance information for instances that do not possess

--- a/openml-utils/src/main/java/com/feedzai/openml/util/data/InstanceUtils.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/data/InstanceUtils.java
@@ -21,6 +21,10 @@ import com.feedzai.openml.data.Instance;
 import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.data.schema.StringValueSchema;
 
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+
 /**
  * Utility class to help computing instance information for instances that do not possess
  * {@link StringValueSchema String} fields.
@@ -42,10 +46,11 @@ public final class InstanceUtils {
      *
      * @param instance The {@link Instance} to get the class value for.
      * @param schema   The {@link DatasetSchema} of the Instance.
-     * @return The target field value as double.
+     * @return The target field value as double wrapped in an {@link Optional}, or {@link Optional#empty()} if no target variable is defined.
      */
-    public static double getClassValue(final Instance instance, final DatasetSchema schema) {
-        return instance.getValue(schema.getTargetIndex());
+    public static Optional<Double> getClassValue(final Instance instance, final DatasetSchema schema) {
+        return schema.getTargetIndex()
+                .map(instance::getValue);
     }
 
     /**
@@ -57,7 +62,9 @@ public final class InstanceUtils {
      * target variable has a value present.
      */
     public static boolean isMissingClass(final Instance instance, final DatasetSchema schema) {
-        return Double.isNaN(getClassValue(instance, schema));
+        return getClassValue(instance, schema)
+                .map(value -> Double.isNaN(value))
+                .orElse(true);
     }
 
     /**

--- a/openml-utils/src/main/java/com/feedzai/openml/util/jackson/deserializer/DatasetSchemaDeserializer.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/jackson/deserializer/DatasetSchemaDeserializer.java
@@ -29,6 +29,7 @@ import com.feedzai.openml.data.schema.FieldSchema;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Custom {@link JsonDeserializer} for known {@link DatasetSchema} instances.
@@ -69,7 +70,8 @@ public class DatasetSchemaDeserializer extends StdDeserializer<DatasetSchema> {
                                      final DeserializationContext deserializationContext) throws IOException {
         final JsonNode treeNode = jsonParser.getCodec().readTree(jsonParser);
 
-        final int targetIndex = (int) treeNode.get(TARGET_INDEX).numberValue();
+        final Optional<Integer> targetIndex = Optional.ofNullable(treeNode.get(TARGET_INDEX))
+                .map(JsonNode::intValue);
 
         final TreeNode fieldNode = treeNode.get(FIELD_SCHEMAS);
         final List<FieldSchema> schemaList = jsonParser.getCodec().readValue(
@@ -77,6 +79,8 @@ public class DatasetSchemaDeserializer extends StdDeserializer<DatasetSchema> {
                 new TypeReference<List<FieldSchema>>() { }
         );
 
-        return new DatasetSchema(targetIndex, schemaList);
+        return targetIndex
+                .map(index -> new DatasetSchema(index, schemaList))
+                .orElse(new DatasetSchema(schemaList));
     }
 }

--- a/openml-utils/src/main/java/com/feedzai/openml/util/jackson/serializers/DatasetSchemaSerializer.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/jackson/serializers/DatasetSchemaSerializer.java
@@ -25,6 +25,8 @@ import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.util.jackson.deserializer.DatasetSchemaDeserializer;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 /**
  * Custom {@link JsonSerializer} for known {@link DatasetSchema} instances.
@@ -33,6 +35,11 @@ import java.io.IOException;
  * @since 0.1.0
  */
 public class DatasetSchemaSerializer extends StdSerializer<DatasetSchema> {
+
+    /**
+     * Serial id for this class.
+     */
+    private static final long serialVersionUID = 6146242224085830807L;
 
     /**
      * Constructor of this object.
@@ -56,7 +63,10 @@ public class DatasetSchemaSerializer extends StdSerializer<DatasetSchema> {
                           final SerializerProvider serializerProvider) throws IOException {
 
         jsonGenerator.writeStartObject();
-        jsonGenerator.writeNumberField(DatasetSchemaDeserializer.TARGET_INDEX, datasetSchema.getTargetIndex());
+        final Optional<Integer> targetIndex = datasetSchema.getTargetIndex();
+        if (targetIndex.isPresent()) {
+            jsonGenerator.writeNumberField(DatasetSchemaDeserializer.TARGET_INDEX, targetIndex.get());
+        }
         jsonGenerator.writeObjectField(DatasetSchemaDeserializer.FIELD_SCHEMAS, datasetSchema.getFieldSchemas());
         jsonGenerator.writeEndObject();
     }

--- a/openml-utils/src/main/java/com/feedzai/openml/util/jackson/serializers/DatasetSchemaSerializer.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/util/jackson/serializers/DatasetSchemaSerializer.java
@@ -26,7 +26,6 @@ import com.feedzai.openml.util.jackson.deserializer.DatasetSchemaDeserializer;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.OptionalInt;
 
 /**
  * Custom {@link JsonSerializer} for known {@link DatasetSchema} instances.

--- a/openml-utils/src/test/java/com/feedzai/openml/util/ClassificationDatasetSchemaUtilTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/ClassificationDatasetSchemaUtilTest.java
@@ -48,7 +48,7 @@ public class ClassificationDatasetSchemaUtilTest {
                 .forEach(numClasses ->
                         assertThat(ClassificationDatasetSchemaUtil.getNumClassValues(createClassificationDatasetSchema(numClasses)))
                                 .as("The number of classes")
-                                .isEqualTo(numClasses));
+                                .hasValue(numClasses));
     }
 
     /**

--- a/openml-utils/src/test/java/com/feedzai/openml/util/jackson/DatasetSchemaSerializationTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/jackson/DatasetSchemaSerializationTest.java
@@ -22,8 +22,14 @@ import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.util.data.schema.TestDatasetSchemaBuilder;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * Tests for the serialization of {@link DatasetSchema}.
@@ -31,7 +37,24 @@ import java.io.IOException;
  * @author Paulo Pereira (paulo.pereira@feedzai.com)
  * @since 0.1.0
  */
+@RunWith(Parameterized.class)
 public class DatasetSchemaSerializationTest {
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        final DatasetSchema schema = TestDatasetSchemaBuilder.builder()
+                .withCategoricalFields(2)
+                .withNumericalFields(3)
+                .withStringFields(1)
+                .build();
+
+        return Arrays.asList(new Object[][] {
+                {schema}, {new DatasetSchema(schema.getFieldSchemas())}
+        });
+    }
+
+    @Parameter
+    public DatasetSchema schema;
 
     /**
      * Checks that is possible to serialize an instance of {@link DatasetSchema} in a JSON.
@@ -43,24 +66,11 @@ public class DatasetSchemaSerializationTest {
         final ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new SerializersInModule());
 
-        final DatasetSchema datasetSchemaModel = createDatasetSchema();
-        final String datasetSchemaJSON = mapper.writeValueAsString(datasetSchemaModel);
+        final String datasetSchemaJSON = mapper.writeValueAsString(this.schema);
 
         final DatasetSchema deserializableJSONContextModel = mapper.readValue(datasetSchemaJSON, DatasetSchema.class);
 
-        Assert.assertEquals(datasetSchemaModel, deserializableJSONContextModel);
+        Assert.assertEquals(this.schema, deserializableJSONContextModel);
     }
 
-    /**
-     * Creates a dummy {@link DatasetSchema} to use in tests.
-     *
-     * @return a instance of {@link DatasetSchema}.
-     */
-    private DatasetSchema createDatasetSchema() {
-        return TestDatasetSchemaBuilder.builder()
-                .withCategoricalFields(2)
-                .withNumericalFields(3)
-                .withStringFields(1)
-                .build();
-    }
 }

--- a/openml-utils/src/test/java/com/feedzai/openml/util/jackson/DatasetSchemaSerializationTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/jackson/DatasetSchemaSerializationTest.java
@@ -20,7 +20,6 @@ package com.feedzai.openml.util.jackson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.util.data.schema.TestDatasetSchemaBuilder;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -31,6 +30,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * Tests for the serialization of {@link DatasetSchema}.
  *
@@ -39,6 +40,9 @@ import java.util.Collection;
  */
 @RunWith(Parameterized.class)
 public class DatasetSchemaSerializationTest {
+
+    @Parameter
+    public DatasetSchema schema;
 
     @Parameters
     public static Collection<Object[]> data() {
@@ -52,9 +56,6 @@ public class DatasetSchemaSerializationTest {
                 {schema}, {new DatasetSchema(schema.getFieldSchemas())}
         });
     }
-
-    @Parameter
-    public DatasetSchema schema;
 
     /**
      * Checks that is possible to serialize an instance of {@link DatasetSchema} in a JSON.
@@ -70,7 +71,7 @@ public class DatasetSchemaSerializationTest {
 
         final DatasetSchema deserializableJSONContextModel = mapper.readValue(datasetSchemaJSON, DatasetSchema.class);
 
-        Assert.assertEquals(this.schema, deserializableJSONContextModel);
+        assertEquals(this.schema, deserializableJSONContextModel);
     }
 
 }


### PR DESCRIPTION
Summary:
This commit changes dataset schemas (DatasetSchema) such that target variables are no longer needed. This was a limitation for Machine Learning Models, as certain
algorithms (mostly in unsupervised learning) have no notion of target variable, as they do not interpret class information.

Thus, from this commit, it is now possible to implement providers with algorithms of, for instance, unsupervised learning.