### PR TITLE
Add DatasetSchema.getTargetVariableField to support optional target variables

### DIFF
--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
@@ -136,14 +136,15 @@ public class DatasetSchema implements Serializable {
      * @return the list of predictive fields.
      */
     public List<FieldSchema> getPredictiveFields() {
-        if (!getTargetIndex().isPresent()) {
+        final Optional<Integer> targetIndex = getTargetIndex();
+
+        if (!targetIndex.isPresent()) {
             return this.fieldSchemas;
         }
-        final int targetIndex = getTargetIndex().get();
 
         return this.fieldSchemas
                 .stream()
-                .filter(field -> field.getFieldIndex() != targetIndex)
+                .filter(field -> field.getFieldIndex() != targetIndex.get())
                 .collect(Collectors.toList());
     }
 

--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
@@ -99,7 +99,7 @@ public class DatasetSchema implements Serializable {
                 fieldSchemas.size() == fieldSchemas.stream().map(FieldSchema::getFieldName).collect(Collectors.toSet()).size(),
         "field schemas should have unique names");
 
-        return fieldSchemas;
+        return ImmutableList.copyOf(fieldSchemas);
     }
 
     /**
@@ -124,17 +124,33 @@ public class DatasetSchema implements Serializable {
      * Gets the {@link FieldSchema} for the target field.
      *
      * @return The target {@link FieldSchema field schema}.
+     * @throws IndexOutOfBoundsException if the target variable is not set for this schema.
+     * @deprecated use {@link #getTargetVariableField()} instead.
      */
+    @Deprecated
     public FieldSchema getTargetFieldSchema() {
         return this.fieldSchemas.get(this.targetIndex);
     }
 
     /**
-     * Gets the list of predictive fields (i.e., {@link #getTargetFieldSchema() non target field}).
+     * Gets the {@link FieldSchema} identified as target variable, if one exists. The result of this method is consistent with {@link #getTargetIndex()}.
+     *
+     * @return The {@link FieldSchema} marked as target variable, if one exists.
+     */
+    public Optional<FieldSchema> getTargetVariableField() {
+        return getTargetIndex()
+                .map(this.fieldSchemas::get);
+    }
+
+    /**
+     * Gets the list of predictive fields (i.e., {@link #getTargetVariableField()} () non target field}).
      *
      * @return the list of predictive fields.
      */
     public List<FieldSchema> getPredictiveFields() {
+        if (!getTargetIndex().isPresent()) {
+            return this.fieldSchemas;
+        }
         return this.fieldSchemas
                 .stream()
                 .filter(field -> field.getFieldIndex() != this.targetIndex)

--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
@@ -139,9 +139,11 @@ public class DatasetSchema implements Serializable {
         if (!getTargetIndex().isPresent()) {
             return this.fieldSchemas;
         }
+        final int targetIndex = getTargetIndex().get();
+
         return this.fieldSchemas
                 .stream()
-                .filter(field -> field.getFieldIndex() != this.targetIndex)
+                .filter(field -> field.getFieldIndex() != targetIndex)
                 .collect(Collectors.toList());
     }
 

--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
@@ -131,7 +131,7 @@ public class DatasetSchema implements Serializable {
     }
 
     /**
-     * Gets the list of predictive fields (i.e., {@link #getTargetFieldSchema()} () non target field}).
+     * Gets the list of predictive fields (i.e., {@link #getTargetFieldSchema() non target field}).
      *
      * @return the list of predictive fields.
      */

--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
@@ -121,29 +121,17 @@ public class DatasetSchema implements Serializable {
     }
 
     /**
-     * Gets the {@link FieldSchema} for the target field.
-     *
-     * @return The target {@link FieldSchema field schema}.
-     * @throws IndexOutOfBoundsException if the target variable is not set for this schema.
-     * @deprecated use {@link #getTargetVariableField()} instead.
-     */
-    @Deprecated
-    public FieldSchema getTargetFieldSchema() {
-        return this.fieldSchemas.get(this.targetIndex);
-    }
-
-    /**
      * Gets the {@link FieldSchema} identified as target variable, if one exists. The result of this method is consistent with {@link #getTargetIndex()}.
      *
      * @return The {@link FieldSchema} marked as target variable, if one exists.
      */
-    public Optional<FieldSchema> getTargetVariableField() {
+    public Optional<FieldSchema> getTargetFieldSchema() {
         return getTargetIndex()
                 .map(this.fieldSchemas::get);
     }
 
     /**
-     * Gets the list of predictive fields (i.e., {@link #getTargetVariableField()} () non target field}).
+     * Gets the list of predictive fields (i.e., {@link #getTargetFieldSchema()} () non target field}).
      *
      * @return the list of predictive fields.
      */

--- a/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
@@ -19,6 +19,7 @@ package com.feedzai.openml.data.schema;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
 
 import java.util.List;
@@ -57,8 +58,14 @@ public class DatasetSchemaTest {
      */
     @Test
     public final void testNoTargetIndex() {
-        assertThat(new DatasetSchema(ImmutableList.of(FIELD_SCHEMA)).getTargetIndex())
+        final SoftAssertions assertions = new SoftAssertions();
+        final DatasetSchema schema = new DatasetSchema(ImmutableList.of(FIELD_SCHEMA));
+        assertions.assertThat(schema.getTargetIndex())
                 .as("A dataset with no target variable")
+                .isNotPresent();
+
+        assertions.assertThat(schema.getTargetVariableField())
+                .as("A dataset with no target variable should not return any field.")
                 .isNotPresent();
     }
 
@@ -101,6 +108,9 @@ public class DatasetSchemaTest {
 
         assertThat(datasetSchema.getTargetFieldSchema())
                 .isEqualTo(targetField);
+
+        assertThat(datasetSchema.getTargetVariableField())
+                .contains(targetField);
 
         assertThat(datasetSchema.getPredictiveFields())
                 .isEqualTo(predictiveFields);

--- a/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
@@ -109,9 +109,6 @@ public class DatasetSchemaTest {
         assertThat(datasetSchema.getTargetFieldSchema())
                 .contains(targetField);
 
-        assertThat(datasetSchema.getPredictiveFields())
-                .isEqualTo(predictiveFields);
-
         final DatasetSchema anotherSchema = new DatasetSchema(2, predictiveFields);
         assertThat(datasetSchema)
                 .isEqualTo(datasetSchema)
@@ -121,6 +118,43 @@ public class DatasetSchemaTest {
         assertThat(datasetSchema.hashCode())
                 .isEqualTo(datasetSchema.hashCode())
                 .isNotEqualTo(anotherSchema.hashCode());
+    }
+
+    /**
+     * Tests that predictive fields:
+     * <ul>
+     *     <li>Do not include the target field when the schema contains a target field.</li>
+     *     <li>Include all fields when the schema has no field marked as target variable.</li>
+     * </ul>
+     */
+    @Test
+    public final void testPredictiveFieldsDoNotContainTargetField() {
+        final FieldSchema targetField =
+                new FieldSchema("field3", 3, new CategoricalValueSchema(false, ImmutableSet.of("true", "false")));
+
+        final List<FieldSchema> predictiveFields = ImmutableList.of(
+                new FieldSchema("field0", 0, new NumericValueSchema(false)),
+                new FieldSchema("field1", 1, new StringValueSchema(true)),
+                new FieldSchema("field2", 2, new NumericValueSchema(true))
+        );
+
+        final List<FieldSchema> allFields = ImmutableList.<FieldSchema>builder()
+                .addAll(predictiveFields)
+                .add(targetField)
+                .build();
+
+        final DatasetSchema datasetWithTarget = new DatasetSchema(3, allFields);
+        final DatasetSchema datasetNoTarget = new DatasetSchema(allFields);
+
+        assertThat(datasetWithTarget.getPredictiveFields())
+                .as("A dataset with target field will consider all fields but the target as predictive fields")
+                .isEqualTo(predictiveFields)
+                .doesNotContain(targetField);
+
+        assertThat(datasetNoTarget.getPredictiveFields())
+                .as("A dataset with no target field will consider all fields, including the target, as predictive fields")
+                .containsAll(predictiveFields)
+                .contains(targetField);
     }
 
 

--- a/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
@@ -67,6 +67,8 @@ public class DatasetSchemaTest {
         assertions.assertThat(schema.getTargetFieldSchema())
                 .as("A dataset with no target variable should not return any field.")
                 .isNotPresent();
+
+        assertions.assertAll();
     }
 
     /**
@@ -146,15 +148,19 @@ public class DatasetSchemaTest {
         final DatasetSchema datasetWithTarget = new DatasetSchema(3, allFields);
         final DatasetSchema datasetNoTarget = new DatasetSchema(allFields);
 
-        assertThat(datasetWithTarget.getPredictiveFields())
+        final SoftAssertions assertions = new SoftAssertions();
+
+        assertions.assertThat(datasetWithTarget.getPredictiveFields())
                 .as("A dataset with target field will consider all fields but the target as predictive fields")
                 .isEqualTo(predictiveFields)
                 .doesNotContain(targetField);
 
-        assertThat(datasetNoTarget.getPredictiveFields())
+        assertions.assertThat(datasetNoTarget.getPredictiveFields())
                 .as("A dataset with no target field will consider all fields, including the target, as predictive fields")
                 .containsAll(predictiveFields)
                 .contains(targetField);
+
+        assertions.assertAll();
     }
 
 

--- a/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/data/schema/DatasetSchemaTest.java
@@ -64,7 +64,7 @@ public class DatasetSchemaTest {
                 .as("A dataset with no target variable")
                 .isNotPresent();
 
-        assertions.assertThat(schema.getTargetVariableField())
+        assertions.assertThat(schema.getTargetFieldSchema())
                 .as("A dataset with no target variable should not return any field.")
                 .isNotPresent();
     }
@@ -107,9 +107,6 @@ public class DatasetSchemaTest {
                 .isEqualTo(allFields);
 
         assertThat(datasetSchema.getTargetFieldSchema())
-                .isEqualTo(targetField);
-
-        assertThat(datasetSchema.getTargetVariableField())
                 .contains(targetField);
 
         assertThat(datasetSchema.getPredictiveFields())

--- a/openml-utils/src/test/java/com/feedzai/openml/util/validate/ValidationUtilsValidateCategoricalTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/validate/ValidationUtilsValidateCategoricalTest.java
@@ -43,6 +43,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ValidationUtilsValidateCategoricalTest {
 
     /**
+     * Tests that when {@link ValidationUtils#validateCategoricalSchema(DatasetSchema) validating categorical target values} for a schema with no target field,
+     * a {@link ParamValidationError} is returned.
+     */
+    @Test
+    public final void testSchemaWithNoTarget() {
+        final DatasetSchema schemaWithTarget = TestDatasetSchemaBuilder.builder()
+                .withNumericalFields(3)
+                .withCategoricalFields(3, ImmutableSet.of("cat1", "cat2"))
+                .withCategoricalTarget(true)
+                .build();
+        final DatasetSchema schema = new DatasetSchema(schemaWithTarget.getFieldSchemas());
+
+        final Optional<ParamValidationError> validationResult = ValidationUtils.validateCategoricalSchema(schema);
+
+        assertThat(validationResult)
+                .as("Validating a schema with no target fields fails.")
+                .isPresent();
+    }
+
+    /**
      * Validates that the utility method accepts a schema with a {@link CategoricalValueSchema} target variable.
      */
     @Test
@@ -125,40 +145,6 @@ public class ValidationUtilsValidateCategoricalTest {
                         .withCategoricalTarget(useCategorical)
                         .build()
         );
-    }
-
-
-    /**
-     * Builds a list of {@link FieldSchema} consisting of N {@link NumericValueSchema numeric fields} followed by
-     * M {@link CategoricalValueSchema categorical fields}.
-     *
-     * @param numericFields     The number of numerical fields to add.
-     * @param categoricalFields The number of categorical fields to add.
-     * @param categories        The {@link CategoricalValueSchema#getNominalValues() categories} to configure in
-     *                          {@link CategoricalValueSchema categorical fields}.
-     * @return The List of {@link FieldSchema}s.
-     */
-    private List<FieldSchema> buildFieldSchemas(final int numericFields,
-                                                final int categoricalFields,
-                                                final Set<String> categories) {
-        final ImmutableList.Builder<FieldSchema> fieldBuilder = ImmutableList.builder();
-        final int totalFields = numericFields + categoricalFields;
-        for (int fieldIndex = 0; fieldIndex < totalFields; fieldIndex++) {
-            final AbstractValueSchema fieldValueSchema;
-            if (fieldIndex < numericFields) {
-                fieldValueSchema = new NumericValueSchema(true);
-            } else {
-                fieldValueSchema = new CategoricalValueSchema(true, categories);
-            }
-
-            final FieldSchema fieldSchema = new FieldSchema(
-                    "field" + fieldIndex,
-                    fieldIndex,
-                    fieldValueSchema
-            );
-            fieldBuilder.add(fieldSchema);
-        }
-        return fieldBuilder.build();
     }
 
 


### PR DESCRIPTION
Add DatasetSchema.getTargetVariableField as an optional alternative to DatasetSchema.getTargetFieldSchema.

Summary:
As an addition to #46, DatasetSchema.getTargetFieldSchema was deprecated in favor of DatasetSchema.getTargetVariableField, a version which returns an optional FieldSchema
correspondent to the target variable's FieldSchema.

Note that `DatasetSchema.getTargetFieldSchema` can be considered functional, but will throw 
an unpleasant `IndexOutOfBoundsException` if the `DatasetSchema` does not contain a target variable. Note also that the method was deprecated, which does not require a major bump since there's no breaking change.