### PR TITLE
Force Travis CI to run with JDK 8 as otherwise the build is currently failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: java
+dist: trusty
+
+jdk:
+  - oraclejdk8
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 
 # Travis is configured to run on pushed branches and pull requests so if we don't filter branches it runs twice when
 # we push the PR branch in our repo


### PR DESCRIPTION
Our CI builds were failing with a non-understandable fatal error on the
JVM when forking to run the junit tests.

The builds passed locally, so we suspected from JVM changes on CI. Looking
on Travis CI news it seems they bumped the environments automatically to
Java 11, so it must be related: https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8

Forcing the build to run with JDK 8 (which is what we currently support
at Feedzai) seems to have fixed the problem.