### PR TITLE
Add generic test for classify method of concrete openml providers

### DIFF
--- a/openml-api/src/main/java/com/feedzai/openml/model/ClassificationMLModel.java
+++ b/openml-api/src/main/java/com/feedzai/openml/model/ClassificationMLModel.java
@@ -42,7 +42,12 @@ public interface ClassificationMLModel extends MachineLearningModel {
      * @param instance The {@link Instance} to be classified.
      * @return The index of the class nominal value according to the {@link DatasetSchema}
      * provided during training of the model.
+     *
+     * @deprecated The idea is to classify the biggest value of the class probabilities distribution obtained from #getClassDistribution(),
+     *  We no longer need this because we can just obtain the biggest value from the class probabilities distribution itself.
+     *
      */
+    @Deprecated
     int classify(Instance instance);
 
 }

--- a/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
@@ -18,6 +18,7 @@ package com.feedzai.openml.util.provider;
 
 import com.feedzai.openml.data.Instance;
 import com.feedzai.openml.data.schema.DatasetSchema;
+import com.feedzai.openml.mocks.MockInstance;
 import com.feedzai.openml.model.ClassificationMLModel;
 import com.feedzai.openml.provider.MachineLearningProvider;
 import com.feedzai.openml.provider.exception.ModelLoadingException;
@@ -25,14 +26,12 @@ import com.feedzai.openml.provider.exception.ModelTrainingException;
 import com.feedzai.openml.provider.model.MachineLearningModelLoader;
 import com.feedzai.openml.util.algorithm.MLAlgorithmEnum;
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Doubles;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.nio.file.Paths;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -77,6 +76,29 @@ public abstract class AbstractProviderModelBaseTest<M extends ClassificationMLMo
     /* * * * * * * * * * * * * * * * * * * * * * * * * * *
      *                       TESTS                       *
      * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+
+    /**
+     * Checks the method ClassificationBinaryDataRobotModel#classify() if it ensures
+     * that DataRobot classifies correctly the index of maximum value of the scores' list.
+     *
+     * @throws ModelLoadingException If anything goes wrong during loading.
+     * @throws ModelTrainingException If anything goes wrong during training.
+     *
+     */
+    @Test
+    public void classifyIndexOfMaxScoresValue() throws ModelLoadingException, ModelTrainingException {
+        final M model = getFirstModel();
+        final Instance instance = getDummyInstance();
+        final int classificationIndex = model.classify(instance);
+        final double[] scores = model.getClassDistribution(instance);
+        final double maxScore = Arrays.stream(scores).max().getAsDouble();
+
+        assertThat(Doubles.asList(scores).indexOf(maxScore))
+                .as("The index of maximum value")
+                .isEqualTo(classificationIndex);
+    }
+
 
     /**
      * Checks that is possible to get a {@link MachineLearningProvider} given a valid provider and algorithm.

--- a/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
@@ -86,10 +86,8 @@ public abstract class AbstractProviderModelBaseTest<M extends ClassificationMLMo
      *
      * @see ClassificationMLModel
      */
-    @Test
-    public void canGetClassDistributionMaxValueIndex() throws Exception {
-        final M model = getFirstModel();
-        final Instance instance = getDummyInstance();
+    protected void canGetClassDistributionMaxValueIndex(final M model, final Instance instance){
+
         final double[] scores = model.getClassDistribution(instance);
 
         final int classificationIndex = model.classify(instance);

--- a/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractProviderModelBaseTest<M extends ClassificationMLMo
 
 
     /**
-     * Checks the method #classify() to ensures that the providers classify
+     * Checks the method #classify() to ensure that the providers classify
      * correctly the index of the maximum value of the scores list.
      *
      * @throws ModelLoadingException  If anything goes wrong during loading.

--- a/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
@@ -79,8 +79,8 @@ public abstract class AbstractProviderModelBaseTest<M extends ClassificationMLMo
 
 
     /**
-     * Checks the method ClassificationBinaryDataRobotModel#classify() if it ensures
-     * that DataRobot classifies correctly the index of maximum value of the scores' list.
+     * Checks the method #classify() if it ensures correctly the index of the list's maximum value
+     * obtained from the method #getClassDistrubution().
      *
      * @throws ModelLoadingException If anything goes wrong during loading.
      * @throws ModelTrainingException If anything goes wrong during training.

--- a/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
@@ -25,7 +25,6 @@ import com.feedzai.openml.provider.exception.ModelTrainingException;
 import com.feedzai.openml.provider.model.MachineLearningModelLoader;
 import com.feedzai.openml.util.algorithm.MLAlgorithmEnum;
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Doubles;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
@@ -96,7 +95,7 @@ public abstract class AbstractProviderModelBaseTest<M extends ClassificationMLMo
         final double[] scores = model.getClassDistribution(instance);
         final double maxScore = Arrays.stream(scores).max().getAsDouble();
 
-        assertThat(Doubles.asList(scores).indexOf(maxScore))
+        assertThat(Arrays.asList(ArrayUtils.toObject(scores)).indexOf(maxScore))
                 .as("The index of maximum value")
                 .isEqualTo(classificationIndex);
     }

--- a/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
@@ -80,19 +80,20 @@ public abstract class AbstractProviderModelBaseTest<M extends ClassificationMLMo
 
 
     /**
-     * Checks the method #classify() to ensure that the providers classify
-     * correctly the index of the maximum value of the scores list.
+     * Verifies that the {@link ClassificationMLModel#classify(Instance)} " returns the index of the greatest value in
+     * the class probability distribution produced by the calling
+     * {@link ClassificationMLModel#getClassDistribution(Instance)} on the model
      *
-     * @throws ModelLoadingException  If anything goes wrong during loading.
-     * @throws ModelTrainingException If anything goes wrong during training.
+     * @see ClassificationMLModel
      */
     @Test
-    public void classifyIndexOfMaxScoresValue() throws ModelLoadingException, ModelTrainingException {
-
+    public void canGetClassDistributionMaxValueIndex() throws Exception {
         final M model = getFirstModel();
         final Instance instance = getDummyInstance();
-        final int classificationIndex = model.classify(instance);
         final double[] scores = model.getClassDistribution(instance);
+
+        final int classificationIndex = model.classify(instance);
+
         final double maxScore = Arrays.stream(scores).max().getAsDouble();
 
         assertThat(Arrays.asList(ArrayUtils.toObject(scores)).indexOf(maxScore))

--- a/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
@@ -18,7 +18,6 @@ package com.feedzai.openml.util.provider;
 
 import com.feedzai.openml.data.Instance;
 import com.feedzai.openml.data.schema.DatasetSchema;
-import com.feedzai.openml.mocks.MockInstance;
 import com.feedzai.openml.model.ClassificationMLModel;
 import com.feedzai.openml.provider.MachineLearningProvider;
 import com.feedzai.openml.provider.exception.ModelLoadingException;
@@ -30,8 +29,11 @@ import com.google.common.primitives.Doubles;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
-import java.nio.file.Paths;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;

--- a/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractProviderModelBaseTest<M extends ClassificationMLMo
 
 
     /**
-     * Checks the method #classify() if it ensures that the providers classify
+     * Checks the method #classify() to ensures that the providers classify
      * correctly the index of the maximum value of the scores list.
      *
      * @throws ModelLoadingException  If anything goes wrong during loading.

--- a/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
+++ b/openml-utils/src/test/java/com/feedzai/openml/util/provider/AbstractProviderModelBaseTest.java
@@ -81,15 +81,15 @@ public abstract class AbstractProviderModelBaseTest<M extends ClassificationMLMo
 
 
     /**
-     * Checks the method #classify() if it ensures correctly the index of the list's maximum value
-     * obtained from the method #getClassDistrubution().
+     * Checks the method #classify() if it ensures that the providers classify
+     * correctly the index of the maximum value of the scores list.
      *
-     * @throws ModelLoadingException If anything goes wrong during loading.
+     * @throws ModelLoadingException  If anything goes wrong during loading.
      * @throws ModelTrainingException If anything goes wrong during training.
-     *
      */
     @Test
     public void classifyIndexOfMaxScoresValue() throws ModelLoadingException, ModelTrainingException {
+
         final M model = getFirstModel();
         final Instance instance = getDummyInstance();
         final int classificationIndex = model.classify(instance);


### PR DESCRIPTION
The abstract test method AbstractProviderModelBaseTest#classifyIndexOfMaxScoresValue() is done, it is able be called by all the test classes that extend it, which were locally fixed.