### PR TITLE
Change copyright notice to the correct one

### DIFF
--- a/openml-example/src/main/resources/META-INF/services/com.feedzai.mlapi.provider.MachineLearningProvider
+++ b/openml-example/src/main/resources/META-INF/services/com.feedzai.mlapi.provider.MachineLearningProvider
@@ -1,9 +1,16 @@
 #
-# The copyright of this file belongs to Feedzai. The file cannot be
-# reproduced in whole or in part, stored in a retrieval system,
-# transmitted in any form, or by any means electronic, mechanical,
-# photocopying, or otherwise, without the prior permission of the owner.
+# Copyright 2018 Feedzai
 #
-# (c) 2018 Feedzai, Strictly Confidential
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 com.feedzai.openml.example.ExampleMLProvider


### PR DESCRIPTION
One file is not using the correct copyright notice. In order to fix this, the copyright notice was changed.