### PR TITLE
Prepare code for more recent versions of Guava

### DIFF
--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/AbstractValueSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/AbstractValueSchema.java
@@ -18,9 +18,9 @@
 package com.feedzai.openml.data.schema;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Objects;
 import java.io.Serializable;
 
 /**
@@ -78,7 +78,7 @@ public abstract class AbstractValueSchema implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.allowMissing);
+        return Objects.hash(this.allowMissing);
     }
 
     @Override
@@ -90,7 +90,7 @@ public abstract class AbstractValueSchema implements Serializable {
             return false;
         }
         final AbstractValueSchema other = (AbstractValueSchema) obj;
-        return Objects.equal(this.allowMissing, other.allowMissing);
+        return Objects.equals(this.allowMissing, other.allowMissing);
     }
 
     @Override

--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/CategoricalValueSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/CategoricalValueSchema.java
@@ -18,11 +18,11 @@
 package com.feedzai.openml.data.schema;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSortedSet;
 
 import java.util.Set;
+import java.util.Objects;
 import java.util.SortedSet;
 
 /**
@@ -73,7 +73,7 @@ public class CategoricalValueSchema extends AbstractValueSchema {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Objects.hashCode(this.nominalValues);
+        return 31 * super.hashCode() + Objects.hash(this.nominalValues);
     }
 
     @Override
@@ -88,7 +88,7 @@ public class CategoricalValueSchema extends AbstractValueSchema {
             return false;
         }
         final CategoricalValueSchema other = (CategoricalValueSchema) obj;
-        return Objects.equal(this.nominalValues, other.nominalValues);
+        return Objects.equals(this.nominalValues, other.nominalValues);
     }
 
     @Override

--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/DatasetSchema.java
@@ -18,12 +18,12 @@
 package com.feedzai.openml.data.schema;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -150,7 +150,7 @@ public class DatasetSchema implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.targetIndex, this.fieldSchemas);
+        return Objects.hash(this.targetIndex, this.fieldSchemas);
     }
 
     @Override
@@ -162,8 +162,8 @@ public class DatasetSchema implements Serializable {
             return false;
         }
         final DatasetSchema other = (DatasetSchema) obj;
-        return Objects.equal(this.targetIndex, other.targetIndex)
-                && Objects.equal(this.fieldSchemas, other.fieldSchemas);
+        return Objects.equals(this.targetIndex, other.targetIndex)
+                && Objects.equals(this.fieldSchemas, other.fieldSchemas);
     }
 
     @Override

--- a/openml-api/src/main/java/com/feedzai/openml/data/schema/FieldSchema.java
+++ b/openml-api/src/main/java/com/feedzai/openml/data/schema/FieldSchema.java
@@ -18,10 +18,10 @@
 package com.feedzai.openml.data.schema;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Objects;
 import java.io.Serializable;
 
 /**
@@ -102,7 +102,7 @@ public class FieldSchema implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.fieldName, this.fieldIndex, this.valueSchema);
+        return Objects.hash(this.fieldName, this.fieldIndex, this.valueSchema);
     }
 
     @Override
@@ -114,9 +114,9 @@ public class FieldSchema implements Serializable {
             return false;
         }
         final FieldSchema other = (FieldSchema) obj;
-        return Objects.equal(this.fieldName, other.fieldName)
-                && Objects.equal(this.fieldIndex, other.fieldIndex)
-                && Objects.equal(this.valueSchema, other.valueSchema);
+        return Objects.equals(this.fieldName, other.fieldName)
+                && Objects.equals(this.fieldIndex, other.fieldIndex)
+                && Objects.equals(this.valueSchema, other.valueSchema);
     }
 
     @Override

--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/MLAlgorithmDescriptor.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/MLAlgorithmDescriptor.java
@@ -18,9 +18,9 @@
 package com.feedzai.openml.provider.descriptor;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.util.Objects;
 import java.net.URL;
 import java.util.Set;
 
@@ -111,7 +111,7 @@ public class MLAlgorithmDescriptor {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.algorithmName, this.parameters, this.algorithmType, this.documentation);
+        return Objects.hash(this.algorithmName, this.parameters, this.algorithmType, this.documentation);
     }
 
     @Override
@@ -123,10 +123,10 @@ public class MLAlgorithmDescriptor {
             return false;
         }
         final MLAlgorithmDescriptor other = (MLAlgorithmDescriptor) obj;
-        return Objects.equal(this.algorithmName, other.algorithmName)
-                && Objects.equal(this.parameters, other.parameters)
-                && Objects.equal(this.algorithmType, other.algorithmType)
-                && Objects.equal(this.documentation, other.documentation);
+        return Objects.equals(this.algorithmName, other.algorithmName)
+                && Objects.equals(this.parameters, other.parameters)
+                && Objects.equals(this.algorithmType, other.algorithmType)
+                && Objects.equals(this.documentation, other.documentation);
     }
 
     @Override

--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/BooleanFieldType.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/BooleanFieldType.java
@@ -18,8 +18,8 @@
 package com.feedzai.openml.provider.descriptor.fieldtype;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -75,7 +75,7 @@ public class BooleanFieldType implements ModelParameterType {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.defaultTrue);
+        return Objects.hash(this.defaultTrue);
     }
 
     @Override
@@ -87,7 +87,7 @@ public class BooleanFieldType implements ModelParameterType {
             return false;
         }
         final BooleanFieldType other = (BooleanFieldType) obj;
-        return Objects.equal(this.defaultTrue, other.defaultTrue);
+        return Objects.equals(this.defaultTrue, other.defaultTrue);
     }
 
     @Override

--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/ChoiceFieldType.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/ChoiceFieldType.java
@@ -18,10 +18,10 @@
 package com.feedzai.openml.provider.descriptor.fieldtype;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -93,7 +93,7 @@ public class ChoiceFieldType implements ModelParameterType {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.allowedValues, this.defaultValue);
+        return Objects.hash(this.allowedValues, this.defaultValue);
     }
 
     @Override
@@ -105,8 +105,8 @@ public class ChoiceFieldType implements ModelParameterType {
             return false;
         }
         final ChoiceFieldType other = (ChoiceFieldType) obj;
-        return Objects.equal(this.allowedValues, other.allowedValues)
-                && Objects.equal(this.defaultValue, other.defaultValue);
+        return Objects.equals(this.allowedValues, other.allowedValues)
+                && Objects.equals(this.defaultValue, other.defaultValue);
     }
 
     @Override

--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/NumericFieldType.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/NumericFieldType.java
@@ -18,9 +18,9 @@
 package com.feedzai.openml.provider.descriptor.fieldtype;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -176,7 +176,7 @@ public class NumericFieldType implements ModelParameterType {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.minValue, this.maxValue, this.defaultValue, this.parameterType);
+        return Objects.hash(this.minValue, this.maxValue, this.defaultValue, this.parameterType);
     }
 
     @Override
@@ -188,10 +188,10 @@ public class NumericFieldType implements ModelParameterType {
             return false;
         }
         final NumericFieldType other = (NumericFieldType) obj;
-        return Objects.equal(this.minValue, other.minValue)
-                && Objects.equal(this.maxValue, other.maxValue)
-                && Objects.equal(this.defaultValue, other.defaultValue)
-                && Objects.equal(this.parameterType, other.parameterType);
+        return Objects.equals(this.minValue, other.minValue)
+                && Objects.equals(this.maxValue, other.maxValue)
+                && Objects.equals(this.defaultValue, other.defaultValue)
+                && Objects.equals(this.parameterType, other.parameterType);
     }
 
     @Override

--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/ParamValidationError.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/ParamValidationError.java
@@ -18,8 +18,9 @@
 package com.feedzai.openml.provider.descriptor.fieldtype;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+
+import java.util.Objects;
 
 /**
  * A POJO representing a parameter validation error returned from {@link ModelParameterType#validate(String, String)}.
@@ -65,7 +66,7 @@ public class ParamValidationError {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.message);
+        return Objects.hash(this.message);
     }
 
     @Override
@@ -77,7 +78,7 @@ public class ParamValidationError {
             return false;
         }
         final ParamValidationError other = (ParamValidationError) obj;
-        return Objects.equal(this.message, other.message);
+        return Objects.equals(this.message, other.message);
     }
 
     @Override

--- a/openml-utils/src/main/java/com/feedzai/openml/mocks/MockInstance.java
+++ b/openml-utils/src/main/java/com/feedzai/openml/mocks/MockInstance.java
@@ -25,9 +25,9 @@ import com.feedzai.openml.data.schema.NumericValueSchema;
 import com.feedzai.openml.data.schema.StringValueSchema;
 import com.feedzai.openml.util.data.ClassificationDatasetSchemaUtil;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -98,7 +98,7 @@ public class MockInstance implements Instance, Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.values);
+        return Objects.hash(this.values);
     }
 
     @Override
@@ -110,7 +110,7 @@ public class MockInstance implements Instance, Serializable {
             return false;
         }
         final MockInstance other = (MockInstance) obj;
-        return Objects.equal(this.values, other.values);
+        return Objects.equals(this.values, other.values);
     }
 
     @Override


### PR DESCRIPTION
While upgrading guava to version 29-jre some methods where removed. Since we can't release a version with guava upgraded yet we can already remove the use of deprecated methods, and replace it with similar methods.

We also change the way that dependencies are managed to get the versions that openml-api uses.