### PR TITLE
pom: Bump Guava to version 25.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.source>1.8</project.source>
-        <guava.version>18.0</guava.version>
+        <guava.version>25.1-jre</guava.version>
         <commons-lang3.version>3.7</commons-lang3.version>
         <junit.version>4.13.1</junit.version>
         <logback.version>1.2.3</logback.version>


### PR DESCRIPTION
This commit will upgrade the dependency `Guava` to version 25.1.
Note that the other projects that use this one, may also need to upgrade their Guava version to match this one.