### PR TITLE
Added a regex validator for FreeTextFieldType

### DIFF
--- a/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/FreeTextFieldType.java
+++ b/openml-api/src/main/java/com/feedzai/openml/provider/descriptor/fieldtype/FreeTextFieldType.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * A concrete implementation of a {@link ModelParameterType} for parameters whose values are textual.
@@ -37,17 +38,45 @@ public class FreeTextFieldType implements ModelParameterType {
     private final String defaultValue;
 
     /**
+     * A regular expression defining a valid input.
+     */
+    private final Pattern validRegex;
+
+    /**
      * Creates a new instance of this class.
      *
      * @param defaultValue  The default value.
      */
     public FreeTextFieldType(final String defaultValue) {
+        this(defaultValue, null);
+    }
+
+    /**
+     * Creates a new instance of this class.
+     *
+     * @param defaultValue  The default value.
+     * @param validRegex    A regex that matches valid inputs.
+     */
+    public FreeTextFieldType(final String defaultValue, final String validRegex) {
         this.defaultValue = Preconditions.checkNotNull(defaultValue, "defaultValue can't be null.");
+        this.validRegex = validRegex != null ? Pattern.compile(validRegex) : null;
     }
 
     @Override
     public Optional<ParamValidationError> validate(final String parameterName, final String parameterValue) {
-        return Optional.empty();
+        if (this.validRegex == null) {
+            return Optional.empty();
+        }
+
+        if (this.validRegex.matcher(parameterValue).matches()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new ParamValidationError(
+                    parameterName,
+                    parameterValue,
+                    "Should match the following regex: " + this.validRegex
+            ));
+        }
     }
 
     /**

--- a/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/FreeTextFieldTypeTest.java
+++ b/openml-api/src/test/java/com/feedzai/openml/provider/fieldtype/FreeTextFieldTypeTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FreeTextFieldTypeTest extends AbstractConfigFieldTypeTest<FreeTextFieldType> {
 
     /**
-     * Tests the {@link FreeTextFieldType#validate(String, String)} method.
+     * Tests the {@link FreeTextFieldType#validate(String, String)} method with no regex validator string.
      */
     @Test
     public void validate() {
@@ -41,6 +41,28 @@ public class FreeTextFieldTypeTest extends AbstractConfigFieldTypeTest<FreeTextF
         assertValidationResult(fieldType, "param0", null, false);
         assertValidationResult(fieldType, "param1", "", false);
         assertValidationResult(fieldType, "param2", "some string", false);
+    }
+
+    /**
+     * Tests the {@link FreeTextFieldType#validate(String, String)} method using the regex validator constructor.
+     */
+    @Test
+    public void validateRegex() {
+        final FreeTextFieldType fieldType = new FreeTextFieldType("1", "^((\\d+(\\.\\d*)?,)*(\\d+(\\.\\d*)?))$");
+
+        // Test valid inputs
+        assertValidationResult(fieldType, "param0", "1", false);
+        assertValidationResult(fieldType, "param0", "1.", false);
+        assertValidationResult(fieldType, "param1", "1.2", false);
+        assertValidationResult(fieldType, "param0", "1.,2", false);
+        assertValidationResult(fieldType, "param2", "1.2,3,4.5", false);
+        assertValidationResult(fieldType, "param3", "1,2,3.4", false);
+
+        // Test invalid inputs
+        assertValidationResult(fieldType, "param4", "", true);
+        assertValidationResult(fieldType, "param5", "1,", true);
+        assertValidationResult(fieldType, "param6", ",1", true);
+        assertValidationResult(fieldType, "param6", "1.2,3.,", true);
     }
 
     /**


### PR DESCRIPTION
Added an optional regex argument to the constructor of `FreeTextFieldType` to validate the input.

Further discussion found in Issue #68 

Closes #68 